### PR TITLE
Implement use of column expressions for certain validation types for nw-backend tables

### DIFF
--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -10,7 +10,8 @@ except PackageNotFoundError:  # pragma: no cover
 
 # Import objects from the module
 from pointblank.tf import TF
+from pointblank.column import col
 from pointblank.validate import Validate, load_dataset
 from pointblank.thresholds import Thresholds
 
-__all__ = ["TF", "Validate", "Thresholds", "load_dataset"]
+__all__ = ["TF", "Validate", "Thresholds", "col", "load_dataset"]

--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -9,6 +9,7 @@ from narwhals.typing import FrameT
 from pointblank._utils import _column_test_prep, _convert_to_narwhals
 from pointblank.thresholds import _threshold_check
 from pointblank._constants import IBIS_BACKENDS
+from pointblank.column import Column
 
 
 @dataclass
@@ -76,6 +77,8 @@ class Interrogator:
 
     def gt(self) -> FrameT | Any:
 
+        # Ibis backends ---------------------------------------------
+
         if self.tbl_type in IBIS_BACKENDS:
 
             import ibis
@@ -89,17 +92,30 @@ class Interrogator:
                 "pb_is_good_1", "pb_is_good_2"
             )
 
+        # Local backends (Narwhals) ---------------------------------
+
+        compare_expr = _get_compare_expr_nw(compare=self.compare)
+
         return (
             self.x.with_columns(
                 pb_is_good_1=nw.col(self.column).is_null() & self.na_pass,
-                pb_is_good_2=nw.col(self.column) > self.compare,
+                pb_is_good_2=(
+                    nw.col(self.compare.name).is_null() & self.na_pass
+                    if isinstance(self.compare, Column)
+                    else nw.lit(False)
+                ),
+                pb_is_good_3=nw.col(self.column) > compare_expr,
             )
-            .with_columns(pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2"))
-            .drop("pb_is_good_1", "pb_is_good_2")
+            .with_columns(
+                pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2") | nw.col("pb_is_good_3")
+            )
+            .drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
             .to_native()
         )
 
     def lt(self) -> FrameT | Any:
+
+        # Ibis backends ---------------------------------------------
 
         if self.tbl_type in IBIS_BACKENDS:
 
@@ -114,17 +130,30 @@ class Interrogator:
                 "pb_is_good_1", "pb_is_good_2"
             )
 
+        # Local backends (Narwhals) ---------------------------------
+
+        compare_expr = _get_compare_expr_nw(compare=self.compare)
+
         return (
             self.x.with_columns(
                 pb_is_good_1=nw.col(self.column).is_null() & self.na_pass,
-                pb_is_good_2=nw.col(self.column) < self.compare,
+                pb_is_good_2=(
+                    nw.col(self.compare.name).is_null() & self.na_pass
+                    if isinstance(self.compare, Column)
+                    else nw.lit(False)
+                ),
+                pb_is_good_3=nw.col(self.column) < compare_expr,
             )
-            .with_columns(pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2"))
-            .drop("pb_is_good_1", "pb_is_good_2")
+            .with_columns(
+                pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2") | nw.col("pb_is_good_3")
+            )
+            .drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
             .to_native()
         )
 
     def eq(self) -> FrameT | Any:
+
+        # Ibis backends ---------------------------------------------
 
         if self.tbl_type in IBIS_BACKENDS:
 
@@ -139,17 +168,30 @@ class Interrogator:
                 "pb_is_good_1", "pb_is_good_2"
             )
 
+        # Local backends (Narwhals) ---------------------------------
+
+        compare_expr = _get_compare_expr_nw(compare=self.compare)
+
         return (
             self.x.with_columns(
                 pb_is_good_1=nw.col(self.column).is_null() & self.na_pass,
-                pb_is_good_2=nw.col(self.column) == self.compare,
+                pb_is_good_2=(
+                    nw.col(self.compare.name).is_null() & self.na_pass
+                    if isinstance(self.compare, Column)
+                    else nw.lit(False)
+                ),
+                pb_is_good_3=nw.col(self.column) == compare_expr,
             )
-            .with_columns(pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2"))
-            .drop("pb_is_good_1", "pb_is_good_2")
+            .with_columns(
+                pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2") | nw.col("pb_is_good_3")
+            )
+            .drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
             .to_native()
         )
 
     def ne(self) -> FrameT | Any:
+
+        # Ibis backends ---------------------------------------------
 
         if self.tbl_type in IBIS_BACKENDS:
 
@@ -168,19 +210,34 @@ class Interrogator:
                 "pb_is_good_1", "pb_is_good_2"
             )
 
+        # Local backends (Narwhals) ---------------------------------
+
+        compare_expr = _get_compare_expr_nw(compare=self.compare)
+
         return (
             self.x.with_columns(
                 pb_is_good_1=nw.col(self.column).is_null() & self.na_pass,
-                pb_is_good_2=nw.when(~nw.col(self.column).is_null())
-                .then(nw.col(self.column) != self.compare)
+                pb_is_good_2=(
+                    nw.col(self.compare.name).is_null() & self.na_pass
+                    if isinstance(self.compare, Column)
+                    else nw.lit(False)
+                ),
+            )
+            .with_columns(
+                pb_is_good_3=nw.when(~nw.col(self.column).is_null())
+                .then(nw.col(self.column) != compare_expr)
                 .otherwise(False),
             )
-            .with_columns(pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2"))
-            .drop("pb_is_good_1", "pb_is_good_2")
+            .with_columns(
+                pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2") | nw.col("pb_is_good_3")
+            )
+            .drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
             .to_native()
         )
 
     def ge(self) -> FrameT | Any:
+
+        # Ibis backends ---------------------------------------------
 
         if self.tbl_type in IBIS_BACKENDS:
 
@@ -195,17 +252,30 @@ class Interrogator:
                 "pb_is_good_1", "pb_is_good_2"
             )
 
+        # Local backends (Narwhals) ---------------------------------
+
+        compare_expr = _get_compare_expr_nw(compare=self.compare)
+
         return (
             self.x.with_columns(
                 pb_is_good_1=nw.col(self.column).is_null() & self.na_pass,
-                pb_is_good_2=nw.col(self.column) >= self.compare,
+                pb_is_good_2=(
+                    nw.col(self.compare.name).is_null() & self.na_pass
+                    if isinstance(self.compare, Column)
+                    else nw.lit(False)
+                ),
+                pb_is_good_3=nw.col(self.column) >= compare_expr,
             )
-            .with_columns(pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2"))
-            .drop("pb_is_good_1", "pb_is_good_2")
+            .with_columns(
+                pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2") | nw.col("pb_is_good_3")
+            )
+            .drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
             .to_native()
         )
 
     def le(self) -> FrameT | Any:
+
+        # Ibis backends ---------------------------------------------
 
         if self.tbl_type in IBIS_BACKENDS:
 
@@ -220,17 +290,30 @@ class Interrogator:
                 "pb_is_good_1", "pb_is_good_2"
             )
 
+        # Local backends (Narwhals) ---------------------------------
+
+        compare_expr = _get_compare_expr_nw(compare=self.compare)
+
         return (
             self.x.with_columns(
                 pb_is_good_1=nw.col(self.column).is_null() & self.na_pass,
-                pb_is_good_2=nw.col(self.column) <= self.compare,
+                pb_is_good_2=(
+                    nw.col(self.compare.name).is_null() & self.na_pass
+                    if isinstance(self.compare, Column)
+                    else nw.lit(False)
+                ),
+                pb_is_good_3=nw.col(self.column) <= compare_expr,
             )
-            .with_columns(pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2"))
-            .drop("pb_is_good_1", "pb_is_good_2")
+            .with_columns(
+                pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2") | nw.col("pb_is_good_3")
+            )
+            .drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
             .to_native()
         )
 
     def between(self) -> FrameT | Any:
+
+        # Ibis backends ---------------------------------------------
 
         if self.tbl_type in IBIS_BACKENDS:
 
@@ -257,19 +340,58 @@ class Interrogator:
                 pb_is_good_=tbl.pb_is_good_1 | (tbl.pb_is_good_2 & tbl.pb_is_good_3)
             ).drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
 
-        closed = _get_nw_closed_str(closed=self.inclusive)
+        # Local backends (Narwhals) ---------------------------------
 
-        return (
-            self.x.with_columns(
-                pb_is_good_1=nw.col(self.column).is_null() & self.na_pass,
-                pb_is_good_2=nw.col(self.column).is_between(self.low, self.high, closed=closed),
+        low_val = _get_compare_expr_nw(compare=self.low)
+        high_val = _get_compare_expr_nw(compare=self.high)
+
+        tbl = self.x.with_columns(
+            pb_is_good_1=nw.col(self.column).is_null(),  # val is Null in Column
+            pb_is_good_2=(  # lb is Null in Column
+                nw.col(self.low.name).is_null() if isinstance(self.low, Column) else nw.lit(False)
+            ),
+            pb_is_good_3=(  # ub is Null in Column
+                nw.col(self.high.name).is_null() if isinstance(self.high, Column) else nw.lit(False)
+            ),
+            pb_is_good_4=nw.lit(self.na_pass),  # Pass if any Null in lb, val, or ub
+        )
+
+        if self.inclusive[0]:
+            tbl = tbl.with_columns(pb_is_good_5=nw.col(self.column) >= low_val)
+        else:
+            tbl = tbl.with_columns(pb_is_good_5=nw.col(self.column) > low_val)
+
+        if self.inclusive[1]:
+            tbl = tbl.with_columns(pb_is_good_6=nw.col(self.column) <= high_val)
+        else:
+            tbl = tbl.with_columns(pb_is_good_6=nw.col(self.column) < high_val)
+
+        tbl = (
+            tbl.with_columns(
+                pb_is_good_=(
+                    (
+                        (nw.col("pb_is_good_1") | nw.col("pb_is_good_2") | nw.col("pb_is_good_3"))
+                        & nw.col("pb_is_good_4")
+                    )
+                    | (nw.col("pb_is_good_5") & nw.col("pb_is_good_6"))
+                )
             )
-            .with_columns(pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2"))
-            .drop("pb_is_good_1", "pb_is_good_2")
+            .drop(
+                "pb_is_good_1",
+                "pb_is_good_2",
+                "pb_is_good_3",
+                "pb_is_good_4",
+                "pb_is_good_5",
+                "pb_is_good_6",
+            )
             .to_native()
         )
 
+        return tbl
+
     def outside(self) -> FrameT | Any:
+
+        # Ibis backends ---------------------------------------------
 
         if self.tbl_type in IBIS_BACKENDS:
 
@@ -296,25 +418,78 @@ class Interrogator:
                 pb_is_good_=tbl.pb_is_good_1 | tbl.pb_is_good_2 | tbl.pb_is_good_3
             ).drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
 
-        closed = _get_nw_closed_str(closed=self.inclusive)
+        # Local backends (Narwhals) ---------------------------------
 
-        return (
-            self.x.with_columns(
-                pb_is_good_1=nw.col(self.column).is_null() & self.na_pass,
-                pb_is_good_2=nw.when(~nw.col(self.column).is_null())
-                .then(~nw.col(self.column).is_between(self.low, self.high, closed=closed))
-                .otherwise(False),
+        low_val = _get_compare_expr_nw(compare=self.low)
+        high_val = _get_compare_expr_nw(compare=self.high)
+
+        # closed = _get_nw_closed_str(closed=self.inclusive)
+
+        tbl = self.x.with_columns(
+            pb_is_good_1=nw.col(self.column).is_null(),  # val is Null in Column
+            pb_is_good_2=(  # lb is Null in Column
+                nw.col(self.low.name).is_null() if isinstance(self.low, Column) else nw.lit(False)
+            ),
+            pb_is_good_3=(  # ub is Null in Column
+                nw.col(self.high.name).is_null() if isinstance(self.high, Column) else nw.lit(False)
+            ),
+            pb_is_good_4=nw.lit(self.na_pass),  # Pass if any Null in lb, val, or ub
+        )
+
+        if self.inclusive[0]:
+            tbl = tbl.with_columns(pb_is_good_5=nw.col(self.column) < low_val)
+        else:
+            tbl = tbl.with_columns(pb_is_good_5=nw.col(self.column) <= low_val)
+
+        if self.inclusive[1]:
+            tbl = tbl.with_columns(pb_is_good_6=nw.col(self.column) > high_val)
+        else:
+            tbl = tbl.with_columns(pb_is_good_6=nw.col(self.column) >= high_val)
+
+        tbl = tbl.with_columns(
+            pb_is_good_5=nw.when(nw.col("pb_is_good_5").is_null())
+            .then(False)
+            .otherwise(nw.col("pb_is_good_5")),
+            pb_is_good_6=nw.when(nw.col("pb_is_good_6").is_null())
+            .then(False)
+            .otherwise(nw.col("pb_is_good_6")),
+        )
+
+        tbl = (
+            tbl.with_columns(
+                pb_is_good_=(
+                    (
+                        (nw.col("pb_is_good_1") | nw.col("pb_is_good_2") | nw.col("pb_is_good_3"))
+                        & nw.col("pb_is_good_4")
+                    )
+                    | (
+                        (nw.col("pb_is_good_5") & ~nw.col("pb_is_good_3"))
+                        | (nw.col("pb_is_good_6")) & ~nw.col("pb_is_good_2")
+                    )
+                )
             )
-            .with_columns(pb_is_good_=nw.col("pb_is_good_1") | nw.col("pb_is_good_2"))
-            .drop("pb_is_good_1", "pb_is_good_2")
+            .drop(
+                "pb_is_good_1",
+                "pb_is_good_2",
+                "pb_is_good_3",
+                "pb_is_good_4",
+                "pb_is_good_5",
+                "pb_is_good_6",
+            )
             .to_native()
         )
 
+        return tbl
+
     def isin(self) -> FrameT | Any:
+
+        # Ibis backends ---------------------------------------------
 
         if self.tbl_type in IBIS_BACKENDS:
 
             return self.x.mutate(pb_is_good_=self.x[self.column].isin(self.set))
+
+        # Local backends (Narwhals) ---------------------------------
 
         return self.x.with_columns(
             pb_is_good_=nw.col(self.column).is_in(self.set),
@@ -322,9 +497,13 @@ class Interrogator:
 
     def notin(self) -> FrameT | Any:
 
+        # Ibis backends ---------------------------------------------
+
         if self.tbl_type in IBIS_BACKENDS:
 
             return self.x.mutate(pb_is_good_=self.x[self.column].notin(self.set))
+
+        # Local backends (Narwhals) ---------------------------------
 
         return (
             self.x.with_columns(
@@ -335,6 +514,8 @@ class Interrogator:
         )
 
     def regex(self) -> FrameT | Any:
+
+        # Ibis backends ---------------------------------------------
 
         if self.tbl_type in IBIS_BACKENDS:
 
@@ -348,6 +529,8 @@ class Interrogator:
             return tbl.mutate(pb_is_good_=tbl.pb_is_good_1 | tbl.pb_is_good_2).drop(
                 "pb_is_good_1", "pb_is_good_2"
             )
+
+        # Local backends (Narwhals) ---------------------------------
 
         return (
             self.x.with_columns(
@@ -363,11 +546,15 @@ class Interrogator:
 
     def null(self) -> FrameT | Any:
 
+        # Ibis backends ---------------------------------------------
+
         if self.tbl_type in IBIS_BACKENDS:
 
             return self.x.mutate(
                 pb_is_good_=self.x[self.column].isnull(),
             )
+
+        # Local backends (Narwhals) ---------------------------------
 
         return self.x.with_columns(
             pb_is_good_=nw.col(self.column).is_null(),
@@ -375,11 +562,15 @@ class Interrogator:
 
     def not_null(self) -> FrameT | Any:
 
+        # Ibis backends ---------------------------------------------
+
         if self.tbl_type in IBIS_BACKENDS:
 
             return self.x.mutate(
                 pb_is_good_=~self.x[self.column].isnull(),
             )
+
+        # Local backends (Narwhals) ---------------------------------
 
         return self.x.with_columns(
             pb_is_good_=~nw.col(self.column).is_null(),
@@ -882,6 +1073,18 @@ class NumberOfTestUnits:
             # Get the count of test units and convert to a native format
             # TODO: check whether pandas or polars is available
             return self.df.count().to_polars()
+
+
+def _get_compare_expr_nw(compare: Any) -> Any:
+    if isinstance(compare, Column):
+        return nw.col(compare.name)
+    return compare
+
+
+def _get_compare_null_expr_nw(compare: Any) -> Any:
+    if isinstance(compare, Column):
+        return nw.col(compare.name).is_null()
+    return nw.lit(False)
 
 
 def _get_nw_closed_str(closed: tuple[bool, bool]) -> str:

--- a/pointblank/_utils_check_args.py
+++ b/pointblank/_utils_check_args.py
@@ -48,7 +48,7 @@ def _check_column(column: str | list[str]):
         raise ValueError("`column=` must be a string.")
 
 
-def _check_value_float_int(value: float | int):
+def _check_value_float_int(value: float | int | any):
     """
     Check that input value of the `value=` parameter is a float or integer.
 
@@ -62,8 +62,11 @@ def _check_value_float_int(value: float | int):
     ValueError
         When `value` is not a float or integer.
     """
-    if not isinstance(value, (float, int)) or isinstance(value, bool):
-        raise ValueError("`value=` must be a float or integer.")
+
+    from pointblank.column import Column
+
+    if not isinstance(value, (float, int, Column)) or isinstance(value, bool):
+        raise ValueError("`value=` must be a float, integer, or reference to a column.")
 
 
 def _check_set_types(set: list[float | int | str]):

--- a/pointblank/column.py
+++ b/pointblank/column.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Column:
+    """
+    A class to represent a column in a table.
+    """
+
+    name: str
+
+    def __repr__(self):
+        return self.name
+
+
+def col(name: str) -> Column:
+    """
+    Reference a column in the input table.
+
+    Parameters
+    ----------
+    name
+        The name of the column.
+
+    Returns
+    -------
+    Column
+        A `Column` object representing the column.
+    """
+    return Column(name=name)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -173,35 +173,6 @@ def load_dataset(
 
 
 @dataclass
-class Column:
-    """
-    A class to represent a column in a table.
-    """
-
-    name: str
-
-    def __repr__(self):
-        return self.name
-
-
-def col(name: str) -> Column:
-    """
-    Reference a column in the input table.
-
-    Parameters
-    ----------
-    name
-        The name of the column.
-
-    Returns
-    -------
-    Column
-        A `Column` object representing the column.
-    """
-    return Column(name=name)
-
-
-@dataclass
 class _ValidationInfo:
     """
     Information about a validation to be performed on a table and the results of the interrogation.

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -51,7 +51,7 @@ from pointblank._utils_check_args import (
     _check_boolean_input,
 )
 
-__all__ = ["Validate"]
+__all__ = ["Validate", "load_dataset", "col"]
 
 
 def load_dataset(
@@ -170,6 +170,35 @@ def load_dataset(
             dataset = ibis.connect(f"duckdb://{data_path}").table(dataset)
 
     return dataset
+
+
+@dataclass
+class Column:
+    """
+    A class to represent a column in a table.
+    """
+
+    name: str
+
+    def __repr__(self):
+        return self.name
+
+
+def col(name: str) -> Column:
+    """
+    Reference a column in the input table.
+
+    Parameters
+    ----------
+    name
+        The name of the column.
+
+    Returns
+    -------
+    Column
+        A `Column` object representing the column.
+    """
+    return Column(name=name)
 
 
 @dataclass

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -433,13 +433,14 @@ class Validate:
         active: bool = True,
     ):
         """
-        Validate whether column values are greater than a single value.
+        Are column data greater than a fixed value or data in another column?
 
         The `col_vals_gt()` validation method checks whether column values in a table are
         *greater than* a specified `value=` (the exact comparison used in this function is
-        `col_val > value`). The `value` is specified as a single, literal value. This validation
-        will operate over the number of test units that is equal to the number of rows in the table
-        (determined after any `pre=` mutation has been applied).
+        `col_val > value`). The `value=` can be specified as a single, literal value or as a column
+        name given in `col()`. This validation will operate over the number of test units that is
+        equal to the number of rows in the table (determined after any `pre=` mutation has been
+        applied).
 
         Parameters
         ----------
@@ -447,7 +448,8 @@ class Validate:
             A single column or a list of columns to validate. If multiple columns are supplied,
             there will be a separate validation step generated for each column.
         value
-            The value to compare against.
+            The value to compare against. This can be a single numeric value or a column name given
+            in `col()`.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
@@ -512,13 +514,14 @@ class Validate:
         active: bool = True,
     ):
         """
-        Validate whether column values are less than a single value.
+        Are column data less than a fixed value or data in another column?
 
         The `col_vals_lt()` validation method checks whether column values in a table are
         *less than* a specified `value=` (the exact comparison used in this function is
-        `col_val < value`). The `value` is specified as a single, literal value. This validation
-        will operate over the number of test units that is equal to the number of rows in the table
-        (determined after any `pre=` mutation has been applied).
+        `col_val < value`). The `value=` can be specified as a single, literal value or as a column
+        name given in `col()`. This validation will operate over the number of test units that is
+        equal to the number of rows in the table (determined after any `pre=` mutation has been
+        applied).
 
         Parameters
         ----------
@@ -526,7 +529,8 @@ class Validate:
             A single column or a list of columns to validate. If multiple columns are supplied,
             there will be a separate validation step generated for each column.
         value
-            The value to compare against.
+            The value to compare against. This can be a single numeric value or a column name given
+            in `col()`.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
@@ -591,13 +595,14 @@ class Validate:
         active: bool = True,
     ):
         """
-        Validate whether column values are equal to a single value.
+        Are column data equal to a fixed value or data in another column?
 
         The `col_vals_eq()` validation method checks whether column values in a table are
         *equal to* a specified `value=` (the exact comparison used in this function is
-        `col_val == value`). The `value` is specified as a single, literal value. This validation
-        will operate over the number of test units that is equal to the number of rows in the table
-        (determined after any `pre=` mutation has been applied).
+        `col_val == value`). The `value=` can be specified as a single, literal value or as a column
+        name given in `col()`. This validation will operate over the number of test units that is
+        equal to the number of rows in the table (determined after any `pre=` mutation has been
+        applied).
 
         Parameters
         ----------
@@ -605,7 +610,8 @@ class Validate:
             A single column or a list of columns to validate. If multiple columns are supplied,
             there will be a separate validation step generated for each column.
         value
-            The value to compare against.
+            The value to compare against. This can be a single numeric value or a column name given
+            in `col()`.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
@@ -671,13 +677,14 @@ class Validate:
         active: bool = True,
     ):
         """
-        Validate whether column values are not equal to a single value.
+        Are column data not equal to a fixed value or data in another column?
 
         The `col_vals_ne()` validation method checks whether column values in a table are
         *not equal to* a specified `value=` (the exact comparison used in this function is
-        `col_val != value`). The `value` is specified as a single, literal value. This validation
-        will operate over the number of test units that is equal to the number of rows in the table
-        (determined after any `pre=` mutation has been applied).
+        `col_val != value`). The `value=` can be specified as a single, literal value or as a column
+        name given in `col()`. This validation will operate over the number of test units that is
+        equal to the number of rows in the table (determined after any `pre=` mutation has been
+        applied).
 
         Parameters
         ----------
@@ -685,7 +692,8 @@ class Validate:
             A single column or a list of columns to validate. If multiple columns are supplied,
             there will be a separate validation step generated for each column.
         value
-            The value to compare against.
+            The value to compare against. This can be a single numeric value or a column name given
+            in `col()`.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
@@ -751,13 +759,14 @@ class Validate:
         active: bool = True,
     ):
         """
-        Validate whether column values are greater than or equal to a single value.
+        Are column data greater than or equal to a fixed value or data in another column?
 
         The `col_vals_ge()` validation method checks whether column values in a table are
         *greater than or equal to* a specified `value=` (the exact comparison used in this function
-        is `col_val >= value`). The `value` is specified as a single, literal value. This validation
-        will operate over the number of test units that is equal to the number of rows in the table
-        (determined after any `pre=` mutation has been applied).
+        is `col_val >= value`). The `value=` can be specified as a single, literal value or as a
+        column name given in `col()`. This validation will operate over the number of test units
+        that is equal to the number of rows in the table (determined after any `pre=` mutation has
+        been applied).
 
         Parameters
         ----------
@@ -765,7 +774,8 @@ class Validate:
             A single column or a list of columns to validate. If multiple columns are supplied,
             there will be a separate validation step generated for each column.
         value
-            The value to compare against.
+            The value to compare against. This can be a single numeric value or a column name given
+            in `col()`.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
@@ -831,13 +841,14 @@ class Validate:
         active: bool = True,
     ):
         """
-        Validate whether column values are less than or equal to a single value.
+        Are column data less than or equal to a fixed value or data in another column?
 
         The `col_vals_le()` validation method checks whether column values in a table are
         *less than or equal to* a specified `value=` (the exact comparison used in this function is
-        `col_val <= value`). The `value` is specified as a single, literal value. This validation
-        will operate over the number of test units that is equal to the number of rows in the table
-        (determined after any `pre=` mutation has been applied).
+        `col_val <= value`). The `value=` can be specified as a single, literal value or as a column
+        name given in `col()`. This validation will operate over the number of test units that is
+        equal to the number of rows in the table (determined after any `pre=` mutation has been
+        applied).
 
         Parameters
         ----------
@@ -845,7 +856,8 @@ class Validate:
             A single column or a list of columns to validate. If multiple columns are supplied,
             there will be a separate validation step generated for each column.
         value
-            The value to compare against.
+            The value to compare against. This can be a single numeric value or a column name given
+            in `col()`.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
@@ -913,14 +925,14 @@ class Validate:
         active: bool = True,
     ):
         """
-        Validate whether column values are between two values.
+        Do column data lie between two specified values or data in other columns?
 
         The `col_vals_between()` validation method checks whether column values in a table fall
         within a range. The range is specified with three arguments: `left=`, `right=`, and
-        `inclusive=`. The `left=` and `right=` values specify the lower and upper bounds. The bounds
-        are is specified as single, literal values. This validation will operate over the number of
-        test units that is equal to the number of rows in the table (determined after any `pre=`
-        mutation has been applied).
+        `inclusive=`. The `left=` and `right=` values specify the lower and upper bounds. These
+        bounds can be specified as literal values or as column names provided within `col()`. The
+        validation will operate over the number of test units that is equal to the number of rows in
+        the table (determined after any `pre=` mutation has been applied).
 
         Parameters
         ----------
@@ -928,9 +940,11 @@ class Validate:
             A single column or a list of columns to validate. If multiple columns are supplied,
             there will be a separate validation step generated for each column.
         left
-            The lower bound of the range.
+            The lower bound of the range. Can be a single numeric value or a column name given in
+            `col()`.
         right
-            The upper bound of the range.
+            The upper bound of the range. Can be a single numeric value or a column name given in
+            `col()`.
         inclusive
             A tuple of two boolean values indicating whether the comparison should be inclusive. The
             position of the boolean values correspond to the `left=` and `right=` values,
@@ -1006,14 +1020,14 @@ class Validate:
         active: bool = True,
     ):
         """
-        Validate whether column values are outside of two values.
+        Do column data lie outside of two specified values or data in other columns?
 
         The `col_vals_between()` validation method checks whether column values in a table *do not*
         fall within a certain range. The range is specified with three arguments: `left=`, `right=`,
-        and `inclusive=`. The `left=` and `right=` values specify the lower and upper bounds. The
-        bounds are is specified as single, literal values. This validation will operate over the
-        number of test units that is equal to the number of rows in the table (determined after any
-        `pre=` mutation has been applied).
+        and `inclusive=`. The `left=` and `right=` values specify the lower and upper bounds. These
+        bounds can be specified as literal values or as column names provided within `col()`. The
+        validation will operate over the number of test units that is equal to the number of rows in
+        the table (determined after any `pre=` mutation has been applied).
 
         Parameters
         ----------
@@ -1021,9 +1035,11 @@ class Validate:
             A single column or a list of columns to validate. If multiple columns are supplied,
             there will be a separate validation step generated for each column.
         left
-            The lower bound of the range.
+            The lower bound of the range. Can be a single numeric value or a column name given in
+            `col()`.
         right
-            The upper bound of the range.
+            The upper bound of the range. Can be a single numeric value or a column name given in
+            `col()`.
         inclusive
             A tuple of two boolean values indicating whether the comparison should be inclusive. The
             position of the boolean values correspond to the `left=` and `right=` values,

--- a/tests/test__interrogation.py
+++ b/tests/test__interrogation.py
@@ -3,7 +3,6 @@ import pandas as pd
 import polars as pl
 
 from pointblank._interrogation import (
-    _get_nw_closed_str,
     ColValsCompareOne,
     ColValsCompareTwo,
     ColValsCompareSet,
@@ -23,14 +22,6 @@ def tbl_pl():
 
 
 COLUMN_LIST = ["x", "y", "z", "pb_is_good_"]
-
-
-def test_get_nw_closed_str():
-
-    assert _get_nw_closed_str(closed=(True, True)) == "both"
-    assert _get_nw_closed_str(closed=(True, False)) == "left"
-    assert _get_nw_closed_str(closed=(False, True)) == "right"
-    assert _get_nw_closed_str(closed=(False, False)) == "none"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -1,0 +1,13 @@
+from pointblank.column import Column, col
+
+
+def test_column_class():
+    col1 = Column(name="col1")
+    assert col1.name == "col1"
+    assert str(col1) == "col1"
+
+
+def test_col_function():
+    col1 = col("col1")
+    assert col1.name == "col1"
+    assert str(col1) == "col1"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -15,8 +15,8 @@ import narwhals as nw
 
 from pointblank.validate import (
     Validate,
-    _ValidationInfo,
     load_dataset,
+    _ValidationInfo,
     _process_title_text,
     _get_default_title_text,
     _fmt_lg,
@@ -26,6 +26,7 @@ from pointblank.validate import (
     _get_tbl_type,
 )
 from pointblank.thresholds import Thresholds
+from pointblank.column import col
 
 
 TBL_LIST = [
@@ -1207,6 +1208,155 @@ def test_col_vals_regex(request, tbl_fixture):
         .interrogate()
         .n_passed(i=1)[1]
         == 3
+    )
+
+
+@pytest.mark.parametrize("tbl_fixture", ["tbl_missing_pd", "tbl_missing_pl"])
+def test_col_vals_compare_col_var(request, tbl_fixture):
+
+    # DataFrame({"x": [1, 2, pd.NA, 4], "y": [4, pd.NA, 6, 7], "z": [8, pd.NA, 8, 8]})
+
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    # `col_vals_lt()`
+
+    assert (
+        Validate(tbl.head(2))
+        .col_vals_lt(columns="x", value=col("y"))
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 1
+    )
+    assert (
+        Validate(tbl.head(2))
+        .col_vals_lt(columns="x", value=col("y"), na_pass=True)
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 2
+    )
+
+    # `col_vals_gt()`
+
+    assert (
+        Validate(tbl.head(2))
+        .col_vals_gt(columns="y", value=col("x"))
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 1
+    )
+    assert (
+        Validate(tbl.head(2))
+        .col_vals_gt(columns="y", value=col("x"), na_pass=True)
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 2
+    )
+
+    # `col_vals_eq()`
+
+    if tbl_fixture == "tbl_missing_pd":
+        # Add the zz column which is a near duplicate of the z column
+        tbl_eq = tbl.assign(zz=[pd.NA, 8, 8, 8])
+    else:
+        tbl_eq = tbl.with_columns(pl.Series(name="zz", values=[None, 8, 8, 8]))
+
+    assert (
+        Validate(tbl_eq).col_vals_eq(columns="zz", value=col("z")).interrogate().n_passed(i=1)[1]
+        == 2
+    )
+    assert (
+        Validate(tbl_eq).col_vals_eq(columns="z", value=col("zz")).interrogate().n_passed(i=1)[1]
+        == 2
+    )
+    assert (
+        Validate(tbl_eq)
+        .col_vals_eq(columns="zz", value=col("z"), na_pass=True)
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 4
+    )
+    assert (
+        Validate(tbl_eq)
+        .col_vals_eq(columns="z", value=col("zz"), na_pass=True)
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 4
+    )
+
+    # `col_vals_ne()`
+
+    # TODO: currently, the `col_vals_ne()` works well for Polars but not for Pandas
+    #       the interrogation scheme needs to be further refined to handle this case
+
+    # assert (
+    #    Validate(tbl).col_vals_ne(columns="x", value=col("y")).interrogate().n_passed(i=1)[1] == 2
+    # )
+    # assert (
+    #    Validate(tbl)
+    #    .col_vals_ne(columns="x", value=col("y"), na_pass=True)
+    #    .interrogate()
+    #    .n_passed(i=1)[1]
+    #    == 4
+    # )
+
+    # `col_vals_ge()`
+
+    assert (
+        Validate(tbl).col_vals_ge(columns="z", value=col("x")).interrogate().n_passed(i=1)[1] == 2
+    )
+    assert (
+        Validate(tbl)
+        .col_vals_ge(columns="z", value=col("x"), na_pass=True)
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 4
+    )
+
+    # `col_vals_le()`
+
+    assert (
+        Validate(tbl).col_vals_le(columns="x", value=col("y")).interrogate().n_passed(i=1)[1] == 2
+    )
+    assert (
+        Validate(tbl)
+        .col_vals_le(columns="x", value=col("y"), na_pass=True)
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 4
+    )
+
+    # `col_vals_between()`
+
+    assert (
+        Validate(tbl)
+        .col_vals_between(columns="y", left=col("x"), right=col("z"))
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 2
+    )
+    assert (
+        Validate(tbl)
+        .col_vals_between(columns="y", left=col("x"), right=col("z"), na_pass=True)
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 4
+    )
+
+    # `col_vals_outside()`
+
+    assert (
+        Validate(tbl)
+        .col_vals_outside(columns="z", left=col("x"), right=col("y"))
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 2
+    )
+    assert (
+        Validate(tbl)
+        .col_vals_outside(columns="z", left=col("x"), right=col("y"), na_pass=True)
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 4
     )
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1285,19 +1285,16 @@ def test_col_vals_compare_col_var(request, tbl_fixture):
 
     # `col_vals_ne()`
 
-    # TODO: currently, the `col_vals_ne()` works well for Polars but not for Pandas
-    #       the interrogation scheme needs to be further refined to handle this case
-
-    # assert (
-    #    Validate(tbl).col_vals_ne(columns="x", value=col("y")).interrogate().n_passed(i=1)[1] == 2
-    # )
-    # assert (
-    #    Validate(tbl)
-    #    .col_vals_ne(columns="x", value=col("y"), na_pass=True)
-    #    .interrogate()
-    #    .n_passed(i=1)[1]
-    #    == 4
-    # )
+    assert (
+        Validate(tbl).col_vals_ne(columns="x", value=col("y")).interrogate().n_passed(i=1)[1] == 2
+    )
+    assert (
+        Validate(tbl)
+        .col_vals_ne(columns="x", value=col("y"), na_pass=True)
+        .interrogate()
+        .n_passed(i=1)[1]
+        == 4
+    )
 
     # `col_vals_ge()`
 


### PR DESCRIPTION
For some of the row-based validations, it makes sense to be able to compare across two (or more) columns instead of comparing only to fixed values. For example, with `col_vals_gt()`, you could perform a validation that checks whether values in a column are greater than `5`:

```python
pb.Validate(tbl).col_vals_gt(columns="x", value=5).interrogate()
```

But it can often be the case that you want to verify whether values in the `x` column are greater than values in an adjacent column (`y`), like this:

```python
pb.Validate(tbl).col_vals_gt(columns="x", value=pb.col("y")).interrogate()
``` 

This PR implements the `col()` function and allows it to work in these types of validations:

- `col_vals_gt()`
- `col_vals_lt()`
- `col_vals_ge()`
- `col_vals_le()`
- `col_vals_eq()`
- `col_vals_ne()`
- `col_vals_between()`
- `col_vals_outside()`
