### PR TITLE
Reduce dependencies; split into dependency groups

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install -e .
           python -m pip install ".[dev]"
+          python -m pandas polars ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
       - name: Build docs

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -29,7 +29,7 @@ jobs:
           pip install -e '.[dev]'
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-cov pytest-snapshot pandas polars
+          pip install pytest pytest-cov pytest-snapshot pandas polars ibis-framework
       - name: pytest unit tests
         run: |
           make test

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -29,7 +29,7 @@ jobs:
           pip install -e '.[dev]'
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-cov pytest-snapshot pandas polars ibis-framework
+          pip install pytest pytest-cov pytest-snapshot pandas polars ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0
       - name: pytest unit tests
         run: |
           make test

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -e '.[all]'
+          pip install -e '.[dev]'
       - name: Install test dependencies
         run: |
           pip install pytest pytest-cov pytest-snapshot pandas polars

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,27 +40,45 @@ dependencies = [
     "narwhals>=1.18.4",
     "great_tables>=0.13.0",
     "typing_extensions>=3.10.0.0",
-    "ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0",
 ]
 requires-python = ">=3.10"
 
-[project.optional-dependencies]
+[dependency-groups]
+pd = [
+    "pandas>=2.2.3",
+]
+pl = [
+    "polars>=1.17.1",
+]
+duckdb = [
+    "ibis-framework[duckdb]>=9.5.0",
+]
+mysql = [
+    "ibis-framework[mysql]>=9.5.0",
+]
+postgres = [
+    "ibis-framework[postgres]>=9.5.0",
+]
+sqlite = [
+    "ibis-framework[sqlite]>=9.5.0",
+]
 dev = [
     "black",
     "duckdb>=1.1.3",
-    "jupyter",
-    "quartodoc>=0.8.1; python_version >= '3.9'",
     "griffe==0.38.1",
+    "ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0",
+    "jupyter",
     "nbclient>=0.10.0",
     "nbformat>=5.10.4",
-    "pandas",
-    "polars",
+    "pandas>=2.2.3",
+    "polars>=1.17.1",
     "pre-commit==2.15.0",
     "pyarrow",
     "pyright>=1.1.244",
     "pytest>=3",
     "pytest-cov",
     "pytest-snapshot",
+    "quartodoc>=0.8.1; python_version >= '3.9'",
 ]
 
 [project.urls]


### PR DESCRIPTION
This removes the ibis dependency but allows for installs by supported ibis backend (and also has optional installs for Pandas and Polars). Uses `[dependency-groups]` instead of `[project.optional-dependencies]` in `pyproject.toml` as recommended in #1 .

Fixes #1