### PR TITLE
feat: add `scalar=`/`frame=` arg to several Validate methods

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -3701,6 +3701,16 @@ class Validate:
         """
         Validation report as a GT table.
 
+        The `get_tabular_report()` method returns a GT table object that represents the validation
+        report. This validation table provides a summary of the validation results, including the
+        validation steps, the number of test units, the number of failing test units, and the
+        fraction of failing test units. The table also includes status indicators for the `warn`,
+        `stop`, and `notify` levels.
+
+        You could simply display the validation table without the use of the `get_tabular_report()`
+        method. However, the method provides a way to customize the title of the report. In the
+        future this method may provide additional options for customizing the report.
+
         Parameters
         ----------
         title
@@ -3729,7 +3739,7 @@ class Validate:
         tbl_pl = pl.DataFrame({"x": [1, 2, 3, 4], "y": [4, 5, 6, 7]})
 
         # Validate data using Polars DataFrame
-        v = (
+        validation = (
             pb.Validate(data=tbl_pl, tbl_name="tbl_xy", thresholds=(2, 3, 4))
             .col_vals_gt(columns="x", value=1)
             .col_vals_lt(columns="x", value=3)
@@ -3737,16 +3747,31 @@ class Validate:
             .interrogate()
         )
 
-        # Generate the tabular report
-        v.get_tabular_report()
+        # Look at the validation table
+        validation
         ```
 
-        The title option was set to `":default:"`, which produces a generic title for the report.
-        We can change this to the name of the table by setting the title to `":tbl_name:"`. This
-        will use the string provided in the `tbl_name=` argument of the `Validate` object.
+        The validation table is displayed with a default title ('Validation Report'). We can use the
+        `get_tabular_report()` method to customize the title of the report. For example, we can set
+        the title to the name of the table by using the `title=":tbl_name:"` option. This will use
+        the string provided in the `tbl_name=` argument of the `Validate` object.
+
         ```{python}
-        v.get_tabular_report(title=":tbl_name:")
+        validation.get_tabular_report(title=":tbl_name:")
         ```
+
+        The title of the report is now set to the name of the table, which is 'tbl_xy'. This can be
+        useful if you have multiple tables and want to keep track of which table the validation
+        report is for.
+
+        Alternatively, you can provide your own title for the report.
+
+        ```{python}
+        validation.get_tabular_report(title="Report for Table XY")
+        ```
+
+        The title of the report is now set to 'Report for Table XY'. This can be useful if you want
+        to provide a more descriptive title for the report.
         """
 
         df_lib = _select_df_lib(preference="polars")

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -3092,6 +3092,70 @@ class Validate:
         -------
         dict[int, bool] | bool
             A dictionary of the warning status for each validation step or a scalar value.
+
+        Examples
+        --------
+        In the example below, we'll use a simple Polars DataFrame with three columns (`a`, `b`, and
+        `c`). There will be three validation steps, and the first step will have some failing test
+        units, the rest will be completely passing. We've set thresholds here for each of the steps
+        by using `thresholds=(2, 4, 5)`, which means:
+
+        - the `warn` threshold is `2` failing test units
+        - the `stop` threshold is `4` failing test units
+        - the `notify` threshold is `5` failing test units
+
+        After interrogation, the `warn()` method is used to determine the `warn` status for each
+        validation step.
+
+        ```{python}
+        import polars as pl
+        import pointblank as pb
+
+        tbl = pl.DataFrame(
+            {
+                "a": [7, 4, 9, 7, 12, 3, 10],
+                "b": [9, 8, 10, 5, 10, 6, 2],
+                "c": ["a", "b", "a", "a", "b", "b", "a"]
+            }
+        )
+
+        validation = (
+            pb.Validate(data=tbl, thresholds=(2, 4, 5))
+            .col_vals_gt(columns="a", value=5)
+            .col_vals_lt(columns="b", value=15)
+            .col_vals_in_set(columns="c", set=["a", "b"])
+            .interrogate()
+        )
+
+        validation.warn()
+        ```
+
+        The returned dictionary provides the `warn` status for each validation step. The first step
+        has a `True` value since the number of failing test units meets the threshold for the
+        `warn` level. The second and third steps have `False` values since the number of failing
+        test units was `0`, which is below the threshold for the `warn` level.
+
+        We can also visually inspect the `warn` status across all steps by viewing the validation
+        table:
+
+        ```{python}
+        validation
+        ```
+
+        We can see that there's a filled yellow circle in the first step (far right side, in the
+        `W` column) indicating that the `warn` threshold was met. The other steps have empty yellow
+        circles. This means that thresholds were 'set but not met' in those steps.
+
+        If we wanted to check the `warn` status for a single validation step, we can provide the
+        step number. Also, we could have the value returned as a scalar by setting `scalar=True`
+        (ensuring that `i=` is a scalar).
+
+        ```{python}
+        validation.warn(i=1)
+        ```
+
+        The returned value is `True`, indicating that the first validation step had the `warn`
+        threshold met.
         """
         result = self._get_validation_dict(i, "warn")
         if scalar and isinstance(i, int):
@@ -3132,6 +3196,71 @@ class Validate:
         -------
         dict[int, bool] | bool
             A dictionary of the stopping status for each validation step or a scalar value.
+
+        Examples
+        --------
+        In the example below, we'll use a simple Polars DataFrame with three columns (`a`, `b`, and
+        `c`). There will be three validation steps, and the first step will have some failing test
+        units, the rest will be completely passing. We've set thresholds here for each of the steps
+        by using `thresholds=(2, 4, 5)`, which means:
+
+        - the `warn` threshold is `2` failing test units
+        - the `stop` threshold is `4` failing test units
+        - the `notify` threshold is `5` failing test units
+
+        After interrogation, the `stop()` method is used to determine the `stop` status for each
+        validation step.
+
+        ```{python}
+        import polars as pl
+        import pointblank as pb
+
+        tbl = pl.DataFrame(
+            {
+                "a": [3, 4, 9, 7, 2, 3, 8],
+                "b": [9, 8, 10, 5, 10, 6, 2],
+                "c": ["a", "b", "a", "a", "b", "b", "a"]
+            }
+        )
+
+        validation = (
+            pb.Validate(data=tbl, thresholds=(2, 4, 5))
+            .col_vals_gt(columns="a", value=5)
+            .col_vals_lt(columns="b", value=15)
+            .col_vals_in_set(columns="c", set=["a", "b"])
+            .interrogate()
+        )
+
+        validation.stop()
+        ```
+
+        The returned dictionary provides the `stop` status for each validation step. The first step
+        has a `True` value since the number of failing test units meets the threshold for the
+        `stop` level. The second and third steps have `False` values since the number of failing
+        test units was `0`, which is below the threshold for the `stop` level.
+
+        We can also visually inspect the `stop` status across all steps by viewing the validation
+        table:
+
+        ```{python}
+        validation
+        ```
+
+        We can see that there are filled yellow and red circles in the first step (far right side,
+        in the `W` and `S` columns) indicating that the `warn` and `stop` thresholds were met. The
+        other steps have empty yellow and red circles. This means that thresholds were 'set but not
+        met' in those steps.
+
+        If we wanted to check the `stop` status for a single validation step, we can provide the
+        step number. Also, we could have the value returned as a scalar by setting `scalar=True`
+        (ensuring that `i=` is a scalar).
+
+        ```{python}
+        validation.stop(i=1)
+        ```
+
+        The returned value is `True`, indicating that the first validation step had the `stop`
+        threshold met.
         """
         result = self._get_validation_dict(i, "stop")
         if scalar and isinstance(i, int):
@@ -3172,6 +3301,71 @@ class Validate:
         -------
         dict[int, bool] | bool
             A dictionary of the notification status for each validation step or a scalar value.
+
+        Examples
+        --------
+        In the example below, we'll use a simple Polars DataFrame with three columns (`a`, `b`, and
+        `c`). There will be three validation steps, and the first step will have many failing test
+        units, the rest will be completely passing. We've set thresholds here for each of the steps
+        by using `thresholds=(2, 4, 5)`, which means:
+
+        - the `warn` threshold is `2` failing test units
+        - the `stop` threshold is `4` failing test units
+        - the `notify` threshold is `5` failing test units
+
+        After interrogation, the `notify()` method is used to determine the `notify` status for each
+        validation step.
+
+        ```{python}
+        import polars as pl
+        import pointblank as pb
+
+        tbl = pl.DataFrame(
+            {
+                "a": [2, 4, 4, 7, 2, 3, 8],
+                "b": [9, 8, 10, 5, 10, 6, 2],
+                "c": ["a", "b", "a", "a", "b", "b", "a"]
+            }
+        )
+
+        validation = (
+            pb.Validate(data=tbl, thresholds=(2, 4, 5))
+            .col_vals_gt(columns="a", value=5)
+            .col_vals_lt(columns="b", value=15)
+            .col_vals_in_set(columns="c", set=["a", "b"])
+            .interrogate()
+        )
+
+        validation.notify()
+        ```
+
+        The returned dictionary provides the `notify` status for each validation step. The first step
+        has a `True` value since the number of failing test units meets the threshold for the
+        `notify` level. The second and third steps have `False` values since the number of failing
+        test units was `0`, which is below the threshold for the `notify` level.
+
+        We can also visually inspect the `notify` status across all steps by viewing the validation
+        table:
+
+        ```{python}
+        validation
+        ```
+
+        We can see that there are filled yellow, red, and blue circles in the first step (far right
+        side, in the `W`, `S`, and `N` columns) indicating that the `warn`, `stop`, and `notify`
+        thresholds were met. The other steps have empty yellow, red, and blue circles. This means
+        that thresholds were 'set but not met' in those steps.
+
+        If we wanted to check the `notify` status for a single validation step, we can provide the
+        step number. Also, we could have the value returned as a scalar by setting `scalar=True`
+        (ensuring that `i=` is a scalar).
+
+        ```{python}
+        validation.notify(i=1)
+        ```
+
+        The returned value is `True`, indicating that the first validation step had the `notify`
+        threshold met.
         """
         result = self._get_validation_dict(i, "notify")
         if scalar and isinstance(i, int):

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2923,6 +2923,50 @@ class Validate:
         dict[int, float] | float
             A dictionary of the fraction of passing test units for each validation step or a scalar
             value.
+
+        Examples
+        --------
+        In the example below, we'll use a simple Polars DataFrame with three columns (`a`, `b`, and
+        `c`). There will be three validation steps, all having some failing test units. After
+        interrogation, the `f_passed()` method is used to determine the fraction of passing test
+        units for each validation step.
+
+        ```{python}
+        import polars as pl
+        import pointblank as pb
+
+        tbl = pl.DataFrame(
+            {
+                "a": [7, 4, 9, 7, 12, 3, 10],
+                "b": [9, 8, 10, 5, 10, 6, 2],
+                "c": ["a", "b", "c", "a", "b", "d", "c"]
+            }
+        )
+
+        validation = (
+            pb.Validate(data=tbl)
+            .col_vals_gt(columns="a", value=5)
+            .col_vals_gt(columns="b", value=pb.col("a"))
+            .col_vals_in_set(columns="c", set=["a", "b"])
+            .interrogate()
+        )
+
+        validation.f_passed()
+        ```
+
+        The returned dictionary shows the fraction of passing test units for each validation step.
+        The values are all less than `1` since there were failing test units in each step.
+
+        If we wanted to check the fraction of passing test units for a single validation step, we
+        can provide the step number. Also, we could have the value returned as a scalar by setting
+        `scalar=True` (ensuring that `i=` is a scalar).
+
+        ```{python}
+        validation.f_passed(i=1)
+        ```
+
+        The returned value is the proportion of passing test units for the first validation step
+        (5 passing test units out of 7 total test units).
         """
         result = self._get_validation_dict(i, "f_passed")
         if scalar and isinstance(i, int):
@@ -2964,6 +3008,50 @@ class Validate:
         dict[int, float] | float
             A dictionary of the fraction of failing test units for each validation step or a scalar
             value.
+
+        Examples
+        --------
+        In the example below, we'll use a simple Polars DataFrame with three columns (`a`, `b`, and
+        `c`). There will be three validation steps, all having some failing test units. After
+        interrogation, the `f_failed()` method is used to determine the fraction of failing test
+        units for each validation step.
+
+        ```{python}
+        import polars as pl
+        import pointblank as pb
+
+        tbl = pl.DataFrame(
+            {
+                "a": [7, 4, 9, 7, 12, 3, 10],
+                "b": [9, 8, 10, 5, 10, 6, 2],
+                "c": ["a", "b", "c", "a", "b", "d", "c"]
+            }
+        )
+
+        validation = (
+            pb.Validate(data=tbl)
+            .col_vals_gt(columns="a", value=5)
+            .col_vals_gt(columns="b", value=pb.col("a"))
+            .col_vals_in_set(columns="c", set=["a", "b"])
+            .interrogate()
+        )
+
+        validation.f_failed()
+        ```
+
+        The returned dictionary shows the fraction of failing test units for each validation step.
+        The values are all greater than `0` since there were failing test units in each step.
+
+        If we wanted to check the fraction of failing test units for a single validation step, we
+        can provide the step number. Also, we could have the value returned as a scalar by setting
+        `scalar=True` (ensuring that `i=` is a scalar).
+
+        ```{python}
+        validation.f_failed(i=1)
+        ```
+
+        The returned value is the proportion of failing test units for the first validation step
+        (2 failing test units out of 7 total test units).
         """
         result = self._get_validation_dict(i, "f_failed")
         if scalar and isinstance(i, int):

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2633,6 +2633,16 @@ class Validate:
         """
         Determine if every validation step passed perfectly, with no failing test units.
 
+        The `all_passed()` method determines if every validation step passed perfectly, with no
+        failing test units. This method is useful for quickly checking if the table passed all
+        validation steps with flying colors. If there's even a single failing test unit in any
+        validation step, this method will return `False`.
+
+        This might be overly stringent for some validation plans where failing test units are
+        generally expected and the strategy is to monitor data quality over time. However, some
+        validation plans might be designed to ensure that every test unit passes perfectly (e.g.,
+        checks for column presence, null-checking tests, etc.).
+
         Returns
         -------
         bool
@@ -2643,6 +2653,20 @@ class Validate:
     def n(self, i: int | list[int] | None = None, scalar: bool = False) -> dict[int, int] | int:
         """
         Provides a dictionary of the number of test units for each validation step.
+
+        The `n()` method provides the number of test units for each validation step. This is the
+        total number of test units that were evaluated in the validation step. It is always an
+        integer value.
+
+        Test units are the atomic units of the validation process. Different validations can have
+        different numbers of test units. For example, a validation that checks for the presence of
+        a column in a table will have a single test unit. A validation that checks for the presence
+        of a value in a column will have as many test units as there are rows in the table.
+
+        The method provides a dictionary of the number of test units for each validation step. If
+        the `scalar=True` argument is provided and `i=` is a scalar, the value is returned as a
+        scalar instead of a dictionary. The total number of test units for a validation step is the
+        sum of the number of passing and failing test units (i.e., `n = n_passed + n_failed`).
 
         Parameters
         ----------
@@ -2668,6 +2692,21 @@ class Validate:
     ) -> dict[int, int] | int:
         """
         Provides a dictionary of the number of test units that passed for each validation step.
+
+        The `n_passed()` method provides the number of test units that passed for each validation
+        step. This is the number of test units that passed in the the validation step. It is always
+        some integer value between `0` and the total number of test units.
+
+        Test units are the atomic units of the validation process. Different validations can have
+        different numbers of test units. For example, a validation that checks for the presence of
+        a column in a table will have a single test unit. A validation that checks for the presence
+        of a value in a column will have as many test units as there are rows in the table.
+
+        The method provides a dictionary of the number of passing test units for each validation
+        step. If the `scalar=True` argument is provided and `i=` is a scalar, the value is returned
+        as a scalar instead of a dictionary. Furthermore, a value obtained here will be the
+        complement to the analogous value returned by the `n_failed()` method (i.e.,
+        `n - n_failed`).
 
         Parameters
         ----------
@@ -2695,6 +2734,21 @@ class Validate:
         """
         Provides a dictionary of the number of test units that failed for each validation step.
 
+        The `n_failed()` method provides the number of test units that failed for each validation
+        step. This is the number of test units that did not pass in the the validation step. It is
+        always some integer value between `0` and the total number of test units.
+
+        Test units are the atomic units of the validation process. Different validations can have
+        different numbers of test units. For example, a validation that checks for the presence of
+        a column in a table will have a single test unit. A validation that checks for the presence
+        of a value in a column will have as many test units as there are rows in the table.
+
+        The method provides a dictionary of the number of failing test units for each validation
+        step. If the `scalar=True` argument is provided and `i=` is a scalar, the value is returned
+        as a scalar instead of a dictionary. Furthermore, a value obtained here will be the
+        complement to the analogous value returned by the `n_passed()` method (i.e.,
+        `n - n_passed`).
+
         Parameters
         ----------
         i
@@ -2720,6 +2774,21 @@ class Validate:
     ) -> dict[int, float] | float:
         """
         Provides a dictionary of the fraction of test units that passed for each validation step.
+
+        A measure of the fraction of test units that passed is provided by the `f_passed` attribute.
+        This is the fraction of test units that passed the validation step over the total number of
+        test units. Given this is a fractional value, it will always be in the range of `0` to `1`.
+
+        Test units are the atomic units of the validation process. Different validations can have
+        different numbers of test units. For example, a validation that checks for the presence of
+        a column in a table will have a single test unit. A validation that checks for the presence
+        of a value in a column will have as many test units as there are rows in the table.
+
+        This method provides a dictionary of the fraction of passing test units for each validation
+        step. If the `scalar=True` argument is provided and `i=` is a scalar, the value is returned
+        as a scalar instead of a dictionary. Furthermore, a value obtained here will be the
+        complement to the analogous value returned by the `f_failed()` method (i.e.,
+        `1 - f_failed()`).
 
         Parameters
         ----------
@@ -2747,6 +2816,21 @@ class Validate:
         """
         Provides a dictionary of the fraction of test units that failed for each validation step.
 
+        A measure of the fraction of test units that failed is provided by the `f_failed` attribute.
+        This is the fraction of test units that failed the validation step over the total number of
+        test units. Given this is a fractional value, it will always be in the range of `0` to `1`.
+
+        Test units are the atomic units of the validation process. Different validations can have
+        different numbers of test units. For example, a validation that checks for the presence of
+        a column in a table will have a single test unit. A validation that checks for the presence
+        of a value in a column will have as many test units as there are rows in the table.
+
+        This method provides a dictionary of the fraction of failing test units for each validation
+        step. If the `scalar=True` argument is provided and `i=` is a scalar, the value is returned
+        as a scalar instead of a dictionary. Furthermore, a value obtained here will be the
+        complement to the analogous value returned by the `f_passed()` method (i.e.,
+        `1 - f_passed()`).
+
         Parameters
         ----------
         i
@@ -2773,6 +2857,22 @@ class Validate:
         """
         Provides a dictionary of the warning status for each validation step.
 
+        The warning status (`warn`) for a validation step is `True` if the fraction of failing test
+        units meets or exceeds the threshold for the warning level. Otherwise, the status is
+        `False`.
+
+        The ascribed name of `warn` is semantic and does not imply that a warning message is
+        generated, it is simply a status indicator that could be used to trigger a warning message.
+        Here's how it fits in with other status indicators:
+
+        - `warn`: the status obtained by calling `warn()`, least severe
+        - `stop`: the status obtained by calling `stop()`, middle severity
+        - `notify`: the status obtained by calling `notify()`, most severe
+
+        This method provides a dictionary of the warning status for each validation step. If the
+        `scalar=True` argument is provided and `i=` is a scalar, the value is returned as a scalar
+        instead of a dictionary.
+
         Parameters
         ----------
         i
@@ -2797,6 +2897,22 @@ class Validate:
         """
         Provides a dictionary of the stopping status for each validation step.
 
+        The stopping status (`stop`) for a validation step is `True` if the fraction of failing test
+        units meets or exceeds the threshold for the stopping level. Otherwise, the status is
+        `False`.
+
+        The ascribed name of `stop` is semantic and does not imply that the validation process
+        is halted, it is simply a status indicator that could be used to trigger a stoppage of the
+        validation process. Here's how it fits in with other status indicators:
+
+        - `warn`: the status obtained by calling `warn()`, least severe
+        - `stop`: the status obtained by calling `stop()`, middle severity
+        - `notify`: the status obtained by calling `notify()`, most severe
+
+        This method provides a dictionary of the stopping status for each validation step. If the
+        `scalar=True` argument is provided and `i=` is a scalar, the value is returned as a scalar
+        instead of a dictionary.
+
         Parameters
         ----------
         i
@@ -2820,6 +2936,22 @@ class Validate:
     ) -> dict[int, bool] | bool:
         """
         Provides a dictionary of the notification status for each validation step.
+
+        The notification status (`notify`) for a validation step is `True` if the fraction of
+        failing test units meets or exceeds the threshold for the notification level. Otherwise,
+        the status is `False`.
+
+        The ascribed name of `notify` is semantic and does not imply that a notification message
+        is generated, it is simply a status indicator that could be used to trigger some sort of
+        notification. Here's how it fits in with other status indicators:
+
+        - `warn`: the status obtained by calling `warn()`, least severe
+        - `stop`: the status obtained by calling `stop()`, middle severity
+        - `notify`: the status obtained by calling `notify()`, most severe
+
+        This method provides a dictionary of the notification status for each validation step. If
+        the `scalar=True` argument is provided and `i=` is a scalar, the value is returned as a
+        scalar instead of a dictionary.
 
         Parameters
         ----------
@@ -2848,7 +2980,7 @@ class Validate:
         After the `interrogate()` method has been called, the `get_data_extracts()` method can be
         used to extract the rows that failed in each row-based validation step (e.g.,
         `col_vals_gt()`, etc.). The method returns a dictionary of tables containing the rows that
-        failed in every row-based validation function. If `frame=True` and `i` is a scalar, the
+        failed in every row-based validation function. If `frame=True` and `i=` is a scalar, the
         value is conveniently returned as a table (forgoing the dictionary structure).
 
         Parameters

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -3588,10 +3588,43 @@ class Validate:
 
         Examples
         --------
-        Create a `Validate` plan of two validation steps, focused on testing row values for
-        part of the `small_table` object. Then, use `interrogate()` to put the validation plan into
-        action.
+        Let's create a `Validate` object with three validation steps and then interrogate the data.
 
+        ```{python}
+        import polars as pl
+        import pointblank as pb
+
+        tbl = pl.DataFrame(
+            {
+                "a": [7, 6, 9, 7, 3, 2],
+                "b": [9, 8, 10, 5, 10, 6],
+                "c": ["c", "d", "a", "b", "a", "b"]
+            }
+        )
+
+        validation = (
+            pb.Validate(data=tbl)
+            .col_vals_gt(columns="a", value=5)
+            .col_vals_in_set(columns="c", set=["a", "b"])
+            .interrogate()
+        )
+
+        validation
+        ```
+
+        From the validation table, we can see that the first and second steps each had 4 passing
+        test units. A failing test unit will mark the entire row as failing in the context of the
+        `get_sundered_data()` method. We can use this method to get the rows of data that passed the
+        during interrogation.
+
+        ```{python}
+        validation.get_sundered_data()
+        ```
+
+        The returned DataFrame contains the rows that passed all validation steps. From the six-row
+        input DataFrame, the first two rows and the last two rows had test units that failed
+        validation. Thus the middle two rows are the only ones that passed all validation steps and
+        that's what we see in the returned DataFrame.
         """
 
         # Keep only the validation steps that:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2878,7 +2878,7 @@ class Validate:
         setting `scalar=True` (ensuring that `i=` is a scalar).
 
         ```{python}
-        validation.n_failing(i=1)
+        validation.n_failed(i=1)
         ```
 
         The returned value of `1` is the number of failing test units for the first validation step.

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2636,7 +2636,7 @@ class Validate:
         Returns
         -------
         bool
-            `True` if all validations passed, `False` otherwise.
+            `True` if all validation steps had no failing test units, `False` otherwise.
         """
         return all(validation.all_passed for validation in self.validation_info)
 
@@ -2648,9 +2648,10 @@ class Validate:
         ----------
         i
             The validation step number(s) from which the number of test units is obtained.
-            If `None`, all steps are included.
+            Can be provided as a list of integers or a single integer. If `None`, all steps are
+            included.
         scalar
-            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
+            If `True` and `i=` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
@@ -2672,9 +2673,10 @@ class Validate:
         ----------
         i
             The validation step number(s) from which the number of passing test units is obtained.
-            If `None`, all steps are included.
+            Can be provided as a list of integers or a single integer. If `None`, all steps are
+            included.
         scalar
-            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
+            If `True` and `i=` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
@@ -2697,9 +2699,10 @@ class Validate:
         ----------
         i
             The validation step number(s) from which the number of failing test units is obtained.
-            If `None`, all steps are included.
+            Can be provided as a list of integers or a single integer. If `None`, all steps are
+            included.
         scalar
-            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
+            If `True` and `i=` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
@@ -2722,9 +2725,10 @@ class Validate:
         ----------
         i
             The validation step number(s) from which the fraction of passing test units is obtained.
-            If `None`, all steps are included.
+            Can be provided as a list of integers or a single integer. If `None`, all steps are
+            included.
         scalar
-            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
+            If `True` and `i=` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
@@ -2747,9 +2751,10 @@ class Validate:
         ----------
         i
             The validation step number(s) from which the fraction of failing test units is obtained.
-            If `None`, all steps are included.
+            Can be provided as a list of integers or a single integer. If `None`, all steps are
+            included.
         scalar
-            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
+            If `True` and `i=` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
@@ -2771,10 +2776,10 @@ class Validate:
         Parameters
         ----------
         i
-            The validation step number(s) from which the warning status is obtained.
-            If `None`, all steps are included.
+            The validation step number(s) from which the warning status is obtained. Can be provided
+            as a list of integers or a single integer. If `None`, all steps are included.
         scalar
-            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
+            If `True` and `i=` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
@@ -2795,10 +2800,10 @@ class Validate:
         Parameters
         ----------
         i
-            The validation step number(s) from which the stopping status is obtained.
-            If `None`, all steps are included.
+            The validation step number(s) from which the stopping status is obtained. Can be
+            provided as a list of integers or a single integer. If `None`, all steps are included.
         scalar
-            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
+            If `True` and `i=` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
@@ -2819,10 +2824,10 @@ class Validate:
         Parameters
         ----------
         i
-            The validation step number(s) from which the notification status is obtained.
-            If `None`, all steps are included.
+            The validation step number(s) from which the notification status is obtained. Can be
+            provided as a list of integers or a single integer. If `None`, all steps are included.
         scalar
-            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
+            If `True` and `i=` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
@@ -2849,10 +2854,10 @@ class Validate:
         Parameters
         ----------
         i
-            The validation step number(s) from which the failed rows are obtained. If `None`, all
-            steps are included.
+            The validation step number(s) from which the failed rows are obtained. Can be provided
+            as a list of integers or a single integer. If `None`, all steps are included.
         frame
-            If `True` and `i` is a scalar, return the value as a DataFrame instead of a dictionary.
+            If `True` and `i=` is a scalar, return the value as a DataFrame instead of a dictionary.
 
         Returns
         -------

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2640,7 +2640,7 @@ class Validate:
         """
         return all(validation.all_passed for validation in self.validation_info)
 
-    def n(self, i: int | list[int] | None = None) -> dict[int, int]:
+    def n(self, i: int | list[int] | None = None, scalar: bool = False) -> dict[int, int] | int:
         """
         Provides a dictionary of the number of test units for each validation step.
 
@@ -2649,16 +2649,22 @@ class Validate:
         i
             The validation step number(s) from which the number of test units is obtained.
             If `None`, all steps are included.
+        scalar
+            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
-        dict[int, int]
-            A dictionary of the number of test units for each validation step.
+        dict[int, int] | int
+            A dictionary of the number of test units for each validation step or a scalar value.
         """
+        result = self._get_validation_dict(i, "n")
+        if scalar and isinstance(i, int):
+            return result[i]
+        return result
 
-        return self._get_validation_dict(i, "n")
-
-    def n_passed(self, i: int | list[int] | None = None) -> dict[int, int]:
+    def n_passed(
+        self, i: int | list[int] | None = None, scalar: bool = False
+    ) -> dict[int, int] | int:
         """
         Provides a dictionary of the number of test units that passed for each validation step.
 
@@ -2667,16 +2673,23 @@ class Validate:
         i
             The validation step number(s) from which the number of passing test units is obtained.
             If `None`, all steps are included.
+        scalar
+            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
-        dict[int, int]
-            A dictionary of the number of failing test units for each validation step.
+        dict[int, int] | int
+            A dictionary of the number of passing test units for each validation step or a scalar
+            value.
         """
+        result = self._get_validation_dict(i, "n_passed")
+        if scalar and isinstance(i, int):
+            return result[i]
+        return result
 
-        return self._get_validation_dict(i, "n_passed")
-
-    def n_failed(self, i: int | list[int] | None = None) -> dict[int, int]:
+    def n_failed(
+        self, i: int | list[int] | None = None, scalar: bool = False
+    ) -> dict[int, int] | int:
         """
         Provides a dictionary of the number of test units that failed for each validation step.
 
@@ -2685,16 +2698,23 @@ class Validate:
         i
             The validation step number(s) from which the number of failing test units is obtained.
             If `None`, all steps are included.
+        scalar
+            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
-        dict[int, int]
-            A dictionary of the number of failing test units for each validation step.
+        dict[int, int] | int
+            A dictionary of the number of failing test units for each validation step or a scalar
+            value.
         """
+        result = self._get_validation_dict(i, "n_failed")
+        if scalar and isinstance(i, int):
+            return result[i]
+        return result
 
-        return self._get_validation_dict(i, "n_failed")
-
-    def f_passed(self, i: int | list[int] | None = None) -> dict[int, float]:
+    def f_passed(
+        self, i: int | list[int] | None = None, scalar: bool = False
+    ) -> dict[int, float] | float:
         """
         Provides a dictionary of the fraction of test units that passed for each validation step.
 
@@ -2703,16 +2723,23 @@ class Validate:
         i
             The validation step number(s) from which the fraction of passing test units is obtained.
             If `None`, all steps are included.
+        scalar
+            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
-        dict[int, float]
-            A dictionary of the fraction of passing test units for each validation step.
+        dict[int, float] | float
+            A dictionary of the fraction of passing test units for each validation step or a scalar
+            value.
         """
+        result = self._get_validation_dict(i, "f_passed")
+        if scalar and isinstance(i, int):
+            return result[i]
+        return result
 
-        return self._get_validation_dict(i, "f_passed")
-
-    def f_failed(self, i: int | list[int] | None = None) -> dict[int, float]:
+    def f_failed(
+        self, i: int | list[int] | None = None, scalar: bool = False
+    ) -> dict[int, float] | float:
         """
         Provides a dictionary of the fraction of test units that failed for each validation step.
 
@@ -2721,16 +2748,23 @@ class Validate:
         i
             The validation step number(s) from which the fraction of failing test units is obtained.
             If `None`, all steps are included.
+        scalar
+            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
-        dict[int, float]
-            A dictionary of the fraction of failing test units for each validation step.
+        dict[int, float] | float
+            A dictionary of the fraction of failing test units for each validation step or a scalar
+            value.
         """
+        result = self._get_validation_dict(i, "f_failed")
+        if scalar and isinstance(i, int):
+            return result[i]
+        return result
 
-        return self._get_validation_dict(i, "f_failed")
-
-    def warn(self, i: int | list[int] | None = None) -> dict[int, bool]:
+    def warn(
+        self, i: int | list[int] | None = None, scalar: bool = False
+    ) -> dict[int, bool] | bool:
         """
         Provides a dictionary of the warning status for each validation step.
 
@@ -2739,16 +2773,22 @@ class Validate:
         i
             The validation step number(s) from which the warning status is obtained.
             If `None`, all steps are included.
+        scalar
+            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
-        dict[int, bool]
-            A dictionary of the warning status for each validation step.
+        dict[int, bool] | bool
+            A dictionary of the warning status for each validation step or a scalar value.
         """
+        result = self._get_validation_dict(i, "warn")
+        if scalar and isinstance(i, int):
+            return result[i]
+        return result
 
-        return self._get_validation_dict(i, "warn")
-
-    def stop(self, i: int | list[int] | None = None) -> dict[int, bool]:
+    def stop(
+        self, i: int | list[int] | None = None, scalar: bool = False
+    ) -> dict[int, bool] | bool:
         """
         Provides a dictionary of the stopping status for each validation step.
 
@@ -2757,16 +2797,22 @@ class Validate:
         i
             The validation step number(s) from which the stopping status is obtained.
             If `None`, all steps are included.
+        scalar
+            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
-        dict[int, bool]
-            A dictionary of the stopping status for each validation step.
+        dict[int, bool] | bool
+            A dictionary of the stopping status for each validation step or a scalar value.
         """
+        result = self._get_validation_dict(i, "stop")
+        if scalar and isinstance(i, int):
+            return result[i]
+        return result
 
-        return self._get_validation_dict(i, "stop")
-
-    def notify(self, i: int | list[int] | None = None) -> dict[int, bool]:
+    def notify(
+        self, i: int | list[int] | None = None, scalar: bool = False
+    ) -> dict[int, bool] | bool:
         """
         Provides a dictionary of the notification status for each validation step.
 
@@ -2775,16 +2821,22 @@ class Validate:
         i
             The validation step number(s) from which the notification status is obtained.
             If `None`, all steps are included.
+        scalar
+            If `True` and `i` is a scalar, return the value as a scalar instead of a dictionary.
 
         Returns
         -------
-        dict[int, bool]
-            A dictionary of the notification status for each validation step.
+        dict[int, bool] | bool
+            A dictionary of the notification status for each validation step or a scalar value.
         """
+        result = self._get_validation_dict(i, "notify")
+        if scalar and isinstance(i, int):
+            return result[i]
+        return result
 
-        return self._get_validation_dict(i, "notify")
-
-    def get_data_extracts(self, i: int | list[int] | None = None) -> dict[int, FrameT | None]:
+    def get_data_extracts(
+        self, i: int | list[int] | None = None, frame: bool = False
+    ) -> dict[int, FrameT | None] | FrameT | None:
         """
         Get the rows that failed for each validation step.
 
@@ -2793,14 +2845,19 @@ class Validate:
         i
             The validation step number(s) from which the failed rows are obtained. If `None`, all
             steps are included.
+        frame
+            If `True` and `i` is a scalar, return the value as a DataFrame instead of a dictionary.
 
         Returns
         -------
-        dict[int, FrameT]
+        dict[int, FrameT | None] | FrameT | None
             A dictionary of tables containing the rows that failed in every row-based validation
-            step.
+            step or a DataFrame.
         """
-        return self._get_validation_dict(i, "extract")
+        result = self._get_validation_dict(i, "extract")
+        if frame and isinstance(i, int):
+            return result[i]
+        return result
 
     def get_json_report(
         self, use_fields: list[str] | None = None, exclude_fields: list[str] | None = None

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -26,7 +26,6 @@ from pointblank.validate import (
     _get_tbl_type,
 )
 from pointblank.thresholds import Thresholds
-from pointblank.column import col
 
 
 TBL_LIST = [

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1418,6 +1418,12 @@ def test_get_data_extracts(tbl_missing_pd):
     assert len(extracts_1) == 1
     assert len(extracts_2) == 1
 
+    extracts_1_df = validation.get_data_extracts(i=1, frame=True)
+    extracts_2_df = validation.get_data_extracts(i=2, frame=True)
+
+    assert isinstance(extracts_1_df, pd.DataFrame)
+    assert isinstance(extracts_2_df, pd.DataFrame)
+
 
 @pytest.mark.parametrize("tbl_fixture", TBL_LIST)
 def test_interrogate_with_active_inactive(request, tbl_fixture):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -433,6 +433,46 @@ def test_validation_attr_getters(request, tbl_fixture):
 
 
 @pytest.mark.parametrize("tbl_fixture", TBL_LIST)
+def test_validation_attr_getters_no_dict(request, tbl_fixture):
+
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    v = Validate(tbl).col_vals_gt(columns="x", value=0).interrogate()
+
+    # Get the total number of test units as a dictionary
+    n_val = v.n(i=1, scalar=True)
+    assert n_val == 4
+
+    # Get the number of passing test units
+    n_passed_val = v.n_passed(i=1, scalar=True)
+    assert n_passed_val == 4
+
+    # Get the number of failing test units
+    n_failed_val = v.n_failed(i=1, scalar=True)
+    assert n_failed_val == 0
+
+    # Get the fraction of passing test units
+    f_passed_val = v.f_passed(i=1, scalar=True)
+    assert f_passed_val == 1.0
+
+    # Get the fraction of failing test units
+    f_failed_val = v.f_failed(i=1, scalar=True)
+    assert f_failed_val == 0.0
+
+    # Get the warn status
+    warn_val = v.warn(i=1, scalar=True)
+    assert warn_val is None
+
+    # Get the stop status
+    stop_val = v.stop(i=1, scalar=True)
+    assert stop_val is None
+
+    # Get the notify status
+    notify_val = v.notify(i=1, scalar=True)
+    assert notify_val is None
+
+
+@pytest.mark.parametrize("tbl_fixture", TBL_LIST)
 def test_validation_report(request, tbl_fixture):
 
     tbl = request.getfixturevalue(tbl_fixture)


### PR DESCRIPTION
Some of the validation methods that let you extract pieces of reporting information from a `Validation` object (post-interrogation) have an `i=` argument that let you constrain the collection to certain steps. If providing a scalar integer to `i=` it would be convenient to forego the dictionary structure and just obtain the value or DataFrame (for the `get_data_extracts()` method). This PR adds the `scalar=` or `frame=` arg (the latter for `get_data_extracts()`). If `True` (default is `False`) and `i=` is a scalar value, then this type of return is provided.