### PR TITLE
Add global config options for validation table output

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -40,17 +40,20 @@ quartodoc:
   sections:
     - title: Validate
       desc: >
-        If going down the road of preparing a data quality analysis, you'll need the Validate class
-        to get the process started. The object is given the target table along with a stepwise
-        validation plan composed via validation methods.
+        When peforming data validation, you'll need the `Validate` class to get the process started.
+        It's given the target table and you can optionally provide some metadata and/or failure
+        thresholds (using the `Thresholds` class or through shorthands for this task). The
+        `Validate` class has numerous methods for defining validation steps and for obtaining
+        post-interrogation metrics and data.
       contents:
         - name: Validate
           members: []
         - name: Thresholds
     - title: Validation Steps
       desc: >
-        The validation steps are the individual validation methods that can be used to build a
-        validation plan. These methods are used to interrogate the data and report on the results.
+        Validation steps can be thought of as sequential validations on the target data. We call
+        `Validate`'s validation methods to build up a validation plan: a collection of steps that,
+        in the aggregate, provides good validation coverage.
       contents:
         - name: Validate.col_vals_gt
         - name: Validate.col_vals_lt
@@ -68,7 +71,11 @@ quartodoc:
         - name: Validate.col_exists
     - title: Interrogation and Reporting
       desc: >
-        The interrogation and reporting methods are used to extract data and report on the results.
+        The validation plan is put into action when `interrogate()` is called. The workflow for
+        performing a comprehensive validation is then: (1) `Validate()`, (2) <validation steps>,
+        (3) `interrogate()`. After interrogation of the data, we can view a validation table (by
+        printing the object or using `get_tabular_report()`), extract key metrics, or split the data
+        based on the validation results (with `get_sundered_data()`).
       contents:
         - name: Validate.interrogate
         - name: Validate.get_data_extracts
@@ -86,6 +93,9 @@ quartodoc:
         - name: Validate.notify
     - title: Utilities
       desc: >
-        The utilities group will contain functions that are helpful for the validation process.
+        The utilities group contain functions that are helpful for the validation process. We can
+        load datasets with `load_dataset()` and set global configuration parameters with
+        `pointblank_config()`.
       contents:
         - name: load_dataset
+        - name: pointblank_config

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -95,8 +95,7 @@ quartodoc:
     - title: Utilities
       desc: >
         The utilities group contain functions that are helpful for the validation process. We can
-        load datasets with `load_dataset()` and set global configuration parameters with
-        `pointblank_config()`.
+        load datasets with `load_dataset()` and set global configuration parameters with `config()`.
       contents:
         - name: load_dataset
-        - name: pointblank_config
+        - name: config

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -69,6 +69,7 @@ quartodoc:
         - name: Validate.col_vals_not_null
         - name: Validate.col_vals_regex
         - name: Validate.col_exists
+        - name: col
     - title: Interrogation and Reporting
       desc: >
         The validation plan is put into action when `interrogate()` is called. The workflow for

--- a/docs/get-started/thresholds.qmd
+++ b/docs/get-started/thresholds.qmd
@@ -1,5 +1,5 @@
 ---
-title: Intro
+title: Thresholds
 jupyter: python3
 html-table-processing: none
 ---
@@ -10,7 +10,7 @@ This is a work in progress. It's just an outline for now.
 
 Thresholds enable you to signal failure at different severity levels. In the near future, thresholds will be able to trigger custom actions. For example, when testing a column for NULLs with `col_vals_not_null()` you might want to warn on any NULLs and stop where there are 10% NULLs in the column.
 
-```python
+```{python}
 import pointblank as pb
 
 validation_1 = (
@@ -47,13 +47,13 @@ validation_2 = (
 validation_2
 ```
 
-In this, both the `col_vals_not_null()` and `col_vals_gt()` steps will use the thresholds set in the `Validate()` call. The `threshold=` argument to every validation method will take priority over the globally set value.
+In this, both the `col_vals_not_null()` and `col_vals_gt()` steps will use the `thresholds=` value set in the `Validate()` call. Now, if you want to override these global threshold values for a given validation step, you can always use `threshold=` argument when calling a validation method.
 
 ## Defining Thresholds
 
 ### Threshold shorthands
 
-The fastest way to define a threshold is a use a tuple with entries for WARN, STOP, and NOTIFY levels.
+The fastest way to define a threshold is to use a tuple with entries for `warn`, `stop`, and `nofify` levels.
 
 ```python
 # [WARN, STOP, NOTIFY]
@@ -64,8 +64,8 @@ Validate(data=..., threshold=threshold)
 
 Note that a shorter tuple or even single values are also allowed:
 
-- `(1, 2)`: warn on 1 failure, stop on 2
-- `1` or `(1, )`: warn on 1 failure
+- `(1, 2)`: `warn` state at 1 failing test unit, `stop` state at 2 failing test units
+- `1` or `(1, )`: `warn` state at 1 failing test unit
 
 ### Threshold cutoff values
 

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -11,7 +11,7 @@ except PackageNotFoundError:  # pragma: no cover
 # Import objects from the module
 from pointblank.tf import TF
 from pointblank.column import col
-from pointblank.validate import Validate, load_dataset, pointblank_config
+from pointblank.validate import Validate, load_dataset, config
 from pointblank.thresholds import Thresholds
 
-__all__ = ["TF", "Validate", "Thresholds", "col", "load_dataset", "pointblank_config"]
+__all__ = ["TF", "Validate", "Thresholds", "col", "load_dataset", "config"]

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -11,7 +11,7 @@ except PackageNotFoundError:  # pragma: no cover
 # Import objects from the module
 from pointblank.tf import TF
 from pointblank.column import col
-from pointblank.validate import Validate, load_dataset
+from pointblank.validate import Validate, load_dataset, pointblank_config
 from pointblank.thresholds import Thresholds
 
-__all__ = ["TF", "Validate", "Thresholds", "col", "load_dataset"]
+__all__ = ["TF", "Validate", "Thresholds", "col", "load_dataset", "pointblank_config"]

--- a/pointblank/column.py
+++ b/pointblank/column.py
@@ -60,7 +60,7 @@ def col(name: str) -> Column:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+    pb.config(report_incl_header=False, report_incl_footer=False)
     ```
 
     Suppose we have a table with columns `a` and `b` and we'd like to validate that the values in

--- a/pointblank/column.py
+++ b/pointblank/column.py
@@ -19,16 +19,76 @@ class Column:
 
 def col(name: str) -> Column:
     """
-    Reference a column in the input table.
+    Helper function for referencing a column in the input table.
+
+    Many of the validation methods (i.e., `col_vals_*()` methods) in pointblank have a `value=`
+    argument. These validations are comparisons between column values and a literal value, or,
+    between column values and adjacent values in another column. The `col()` helper function is used
+    to specify that it is a column being referenced, not a literal value.
+
+    The `col()` doesn't check that the column exists in the input table. It acts to signal that the
+    value being compared is a column value. During validation (i.e., when `interrogate()` is
+    called), pointblank will then check that the column exists in the input table.
+
+    This function can be used in the `value=` argument of the following validation methods:
+
+    - `col_vals_gt()`
+    - `col_vals_lt()`
+    - `col_vals_ge()`
+    - `col_vals_le()`
+    - `col_vals_eq()`
+    - `col_vals_ne()`
+    - `col_vals_between()`
+    - `col_vals_outside()`
+
+    For the last two methods cited, `col()` can be used either of the `left=` and `right=`
+    arguments, or both.
 
     Parameters
     ----------
     name
-        The name of the column.
+        The name of the column in the input table.
 
     Returns
     -------
     Column
         A `Column` object representing the column.
+
+    Examples
+    --------
+    ```{python}
+    #| echo: false
+    #| output: false
+    import pointblank as pb
+    pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+    ```
+
+    Suppose we have a table with columns `a` and `b` and we'd like to validate that the values in
+    column `a` are greater than the values in column `b`. We can use the `col()` helper function to
+    reference the comparison column when creating the validation step.
+
+    ```{python}
+    import polars as pl
+    import pointblank as pb
+
+    tbl = pl.DataFrame(
+        {
+            "a": [5, 6, 5, 7, 6, 5],
+            "b": [4, 2, 3, 3, 4, 3],
+        }
+    )
+
+    validation = (
+        pb.Validate(data=tbl)
+        .col_vals_gt(columns="a", value=pb.col("b"))
+        .interrogate()
+    )
+
+    validation
+    ```
+
+    From the excerpt of the validation table, values in `a` were greater than values in `b` for
+    every row (or test unit). Using `value=pb.col("b")` specified that the greater-than comparison
+    is across columns, not with a fixed literal value.
     """
     return Column(name=name)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -3863,9 +3863,9 @@ class Validate:
         """
 
         if incl_header is None:
-            incl_header = PointblankConfig.report_incl_header
+            incl_header = global_config.report_incl_header
         if incl_footer is None:
-            incl_footer = PointblankConfig.report_incl_footer
+            incl_footer = global_config.report_incl_footer
 
         df_lib = _select_df_lib(preference="polars")
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -516,6 +516,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
 
@@ -657,6 +663,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
 
@@ -797,6 +809,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
 
@@ -936,6 +954,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
 
@@ -1073,6 +1097,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
 
@@ -1214,6 +1244,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
 
@@ -1364,6 +1400,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
 
@@ -1525,6 +1567,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
 
@@ -1670,6 +1718,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
 
@@ -1794,6 +1848,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
 
@@ -1917,6 +1977,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
 
@@ -2035,6 +2101,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
 
@@ -2161,6 +2233,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with two string columns (`a` and
         `b`). The table is shown below:
 
@@ -2281,6 +2359,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        ```
         For the examples here, we'll use a simple Polars DataFrame with a string columns (`a`) and a
         numeric column (`b`). The table is shown below:
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -64,7 +64,7 @@ class PointblankConfig:
     report_incl_footer: bool = True
 
     def __repr__(self):
-        return f"PointblankConfig(incl_header={self.report_incl_header}, incl_footer={self.report_incl_footer})"
+        return f"PointblankConfig(report_incl_header={self.report_incl_header}, report_incl_footer={self.report_incl_footer})"
 
 
 # Global configuration instance

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -92,8 +92,8 @@ def config(report_incl_header: bool = True, report_incl_footer: bool = True) -> 
     """
 
     global global_config
-    global_config.report_incl_header = report_incl_header
-    global_config.report_incl_footer = report_incl_footer
+    global_config.report_incl_header = report_incl_header  # pragma: no cover
+    global_config.report_incl_footer = report_incl_footer  # pragma: no cover
 
 
 def load_dataset(

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -51,13 +51,13 @@ from pointblank._utils_check_args import (
     _check_boolean_input,
 )
 
-__all__ = ["Validate", "load_dataset", "pointblank_config"]
+__all__ = ["Validate", "load_dataset", "config"]
 
 
 @dataclass
 class PointblankConfig:
     """
-    Configuration settings for the Pointblank library.
+    Configuration settings for the pointblank library.
     """
 
     report_incl_header: bool = True
@@ -71,20 +71,19 @@ class PointblankConfig:
 global_config = PointblankConfig()
 
 
-def pointblank_config(
-    report_incl_header: bool = True, report_incl_footer: bool = True
-) -> PointblankConfig:
+def config(report_incl_header: bool = True, report_incl_footer: bool = True) -> PointblankConfig:
     """
-    Set the configuration settings for the Pointblank library.
+    Configuration settings for the pointblank library.
 
     Parameters
     ----------
     report_incl_header
-        Whether to include the header in the validation table report. The header contains the table
-        name and label information.
+        This controls whether the header should be present in the validation table report. The
+        header contains the table name, label information, and might contain global failure
+        threshold levels (if set).
     report_incl_footer
-        Whether to include the footer in the validation table report. The footer contains the date
-        and time of the report generation.
+        Should the footer of the validation table report be displayed? The footer contains the
+        starting and ending times of the interrogation.
 
     Returns
     -------
@@ -520,7 +519,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -667,7 +666,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -813,7 +812,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -958,7 +957,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -1101,7 +1100,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -1248,7 +1247,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -1404,7 +1403,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -1571,7 +1570,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -1722,7 +1721,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -1852,7 +1851,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -1981,7 +1980,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -2105,7 +2104,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -2237,7 +2236,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two string columns (`a` and
         `b`). The table is shown below:
@@ -2363,7 +2362,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.pointblank_config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with a string columns (`a`) and a
         numeric column (`b`). The table is shown below:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -67,6 +67,10 @@ class PointblankConfig:
         return f"PointblankConfig(incl_header={self.report_incl_header}, incl_footer={self.report_incl_footer})"
 
 
+# Global configuration instance
+global_config = PointblankConfig()
+
+
 def pointblank_config(
     report_incl_header: bool = True, report_incl_footer: bool = True
 ) -> PointblankConfig:
@@ -88,9 +92,9 @@ def pointblank_config(
         A `PointblankConfig` object with the specified configuration settings.
     """
 
-    return PointblankConfig(
-        report_incl_header=report_incl_header, report_incl_footer=report_incl_footer
-    )
+    global global_config
+    global_config.report_incl_header = report_incl_header
+    global_config.report_incl_footer = report_incl_footer
 
 
 def load_dataset(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -16,6 +16,7 @@ import narwhals as nw
 from pointblank.validate import (
     Validate,
     load_dataset,
+    PointblankConfig,
     _ValidationInfo,
     _process_title_text,
     _get_default_title_text,
@@ -1881,3 +1882,14 @@ def test_get_tbl_type():
 
     assert _get_tbl_type(pd.DataFrame()) == "pandas"
     assert _get_tbl_type(pl.DataFrame()) == "polars"
+
+
+def test_pointblank_config_class():
+
+    # Test the default configuration
+    config = PointblankConfig()
+
+    assert config.report_incl_header is True
+    assert config.report_incl_footer is True
+
+    assert str(config) == "PointblankConfig(report_incl_header=True, report_incl_footer=True)"


### PR DESCRIPTION
This adds a function to set global config options for pointblank. Here, two options are provided: `report_incl_header` and `report_incl_footer`.