### PR TITLE
feat: add options for case-insensitive matching of coltypes and dtypes in schema checks

### DIFF
--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -1622,6 +1622,10 @@ class ColSchemaMatch:
         `True` to check if the schema is complete, `False` otherwise.
     in_order
         `True` to check if the schema is in order, `False` otherwise.
+    case_sensitive_colnames
+        `True` to perform column-name matching in a case-sensitive manner, `False` otherwise.
+    case_sensitive_dtypes
+        `True` to perform data-type matching in a case-sensitive manner, `False` otherwise.
     threshold
         The maximum number of failing test units to allow.
     tbl_type
@@ -1638,6 +1642,8 @@ class ColSchemaMatch:
     schema: any
     complete: bool
     in_order: bool
+    case_sensitive_colnames: bool
+    case_sensitive_dtypes: bool
     threshold: int
 
     def __post_init__(self):

--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -1654,22 +1654,38 @@ class ColSchemaMatch:
         if self.complete and self.in_order:
             # Check if the schema is complete and in order (most restrictive check)
             # complete: True, in_order: True
-            res = schema_expect._compare_schema_columns_complete_in_order(other=schema_actual)
+            res = schema_expect._compare_schema_columns_complete_in_order(
+                other=schema_actual,
+                case_sensitive_colnames=self.case_sensitive_colnames,
+                case_sensitive_dtypes=self.case_sensitive_dtypes,
+            )
 
         elif not self.complete and not self.in_order:
             # Check if the schema is at least a subset, and, order of columns does not matter
             # complete: False, in_order: False
-            res = schema_expect._compare_schema_columns_subset_any_order(other=schema_actual)
+            res = schema_expect._compare_schema_columns_subset_any_order(
+                other=schema_actual,
+                case_sensitive_colnames=self.case_sensitive_colnames,
+                case_sensitive_dtypes=self.case_sensitive_dtypes,
+            )
 
         elif self.complete:
             # Check if the schema is complete, but the order of columns does not matter
             # complete: True, in_order: False
-            res = schema_expect._compare_schema_columns_complete_any_order(other=schema_actual)
+            res = schema_expect._compare_schema_columns_complete_any_order(
+                other=schema_actual,
+                case_sensitive_colnames=self.case_sensitive_colnames,
+                case_sensitive_dtypes=self.case_sensitive_dtypes,
+            )
 
         else:
             # Check if the schema is a subset (doesn't need to be complete) and in order
             # complete: False, in_order: True
-            res = schema_expect._compare_schema_columns_subset_in_order(other=schema_actual)
+            res = schema_expect._compare_schema_columns_subset_in_order(
+                other=schema_actual,
+                case_sensitive_colnames=self.case_sensitive_colnames,
+                case_sensitive_dtypes=self.case_sensitive_dtypes,
+            )
 
         self.test_unit_res = res
 

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -234,6 +234,10 @@ class Schema:
             this_dtype = self.columns[this_column_list.index(col)][1]
             other_dtype = other.columns[other_column_list.index(col)][1]
 
+            if not case_sensitive_dtypes:
+                this_dtype = this_dtype.lower()
+                other_dtype = other_dtype.lower()
+
             if this_dtype != other_dtype:
                 return False
 
@@ -289,6 +293,10 @@ class Schema:
                 # Get the dtype of the column in the other schema
                 other_dtype = other.columns[other_col_index][1]
 
+                if not case_sensitive_dtypes:
+                    this_dtype = this_dtype.lower()
+                    other_dtype = other_dtype.lower()
+
                 if this_dtype != other_dtype:
                     return False
 
@@ -339,6 +347,10 @@ class Schema:
 
                 # Get the dtype of the column in the other schema
                 other_dtype = other.columns[other_col_index][1]
+
+                if not case_sensitive_dtypes:
+                    this_dtype = this_dtype.lower()
+                    other_dtype = other_dtype.lower()
 
                 if this_dtype != other_dtype:
                     return False
@@ -392,6 +404,10 @@ class Schema:
             else:
                 this_dtype = self.columns[this_column_list.index(col)][1]
                 other_dtype = other.columns[other_column_list.index(col)][1]
+
+                if not case_sensitive_dtypes:
+                    this_dtype = this_dtype.lower()
+                    other_dtype = other_dtype.lower()
 
                 if this_dtype != other_dtype:
                     return False

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -190,7 +190,9 @@ class Schema:
                 "The provided table object cannot be converted to a Narwhals DataFrame."
             )
 
-    def _compare_schema_columns_complete_in_order(self, other: Schema) -> bool:
+    def _compare_schema_columns_complete_in_order(
+        self, other: Schema, case_sensitive_colnames: bool, case_sensitive_dtypes: bool
+    ) -> bool:
         """
         Compare the columns of the schema with another schema. Ensure that all column names are the
         same and that they are in the same order. This method is performed when:
@@ -208,35 +210,38 @@ class Schema:
         bool
             True if the columns are the same, False otherwise.
         """
-        this_column_list = self.get_column_list()
-        other_column_list = other.get_column_list()
+
+        if not case_sensitive_colnames:
+            this_column_list = [col.lower() for col in self.get_column_list()]
+            other_column_list = [col.lower() for col in other.get_column_list()]
+        else:
+            this_column_list = self.get_column_list()
+            other_column_list = other.get_column_list()
 
         # Check if the column lists are the same length, this is a quick check to determine
         # if the schemas are different
         if len(this_column_list) != len(other_column_list):
             return False
 
-        # Check that the column names are the same in both schemas
+        # Check that the column names are the same in both schemas and in the same order
         if this_column_list != other_column_list:
             return False
 
-        # Iteratively move through the columns in `this_column_list` and determine if:
-        # - the column is present in `other_column_list` at the same index
-        # - the dtype of the column in `this_column_list` is the same as the dtype in
-        #   `other_column_list`
+        # Iteratively move through the columns in `this_column_list` and determine if the dtype of
+        # the column in `this_column_list` is the same as the dtype in `other_column_list`
         for col in this_column_list:
-            if col not in other_column_list:
-                return False
-            else:
-                this_dtype = self.columns[this_column_list.index(col)][1]
-                other_dtype = other.columns[other_column_list.index(col)][1]
 
-                if this_dtype != other_dtype:
-                    return False
+            this_dtype = self.columns[this_column_list.index(col)][1]
+            other_dtype = other.columns[other_column_list.index(col)][1]
+
+            if this_dtype != other_dtype:
+                return False
 
         return True
 
-    def _compare_schema_columns_complete_any_order(self, other: Schema) -> bool:
+    def _compare_schema_columns_complete_any_order(
+        self, other: Schema, case_sensitive_colnames: bool, case_sensitive_dtypes: bool
+    ) -> bool:
         """
         Compare the columns of the schema with another schema to ensure that all column names are
         available in both schemas. Column order is not considered here. This method is performed
@@ -254,8 +259,13 @@ class Schema:
         bool
             True if the columns are the same, False otherwise.
         """
-        this_column_list = self.get_column_list()
-        other_column_list = other.get_column_list()
+
+        if not case_sensitive_colnames:
+            this_column_list = [col.lower() for col in self.get_column_list()]
+            other_column_list = [col.lower() for col in other.get_column_list()]
+        else:
+            this_column_list = self.get_column_list()
+            other_column_list = other.get_column_list()
 
         # Check if the column names lists are the same length, this is a quick check to determine
         # if the schemas are different
@@ -284,7 +294,9 @@ class Schema:
 
         return True
 
-    def _compare_schema_columns_subset_in_order(self, other: Schema) -> bool:
+    def _compare_schema_columns_subset_in_order(
+        self, other: Schema, case_sensitive_colnames: bool, case_sensitive_dtypes: bool
+    ) -> bool:
         """
         Compare the columns of the schema with another schema. Ensure that all column names in the
         schema are available in the other schema and that they are in the same order. This method is
@@ -303,8 +315,13 @@ class Schema:
         bool
             True if the columns are the same, False otherwise.
         """
-        this_column_list = self.get_column_list()
-        other_column_list = other.get_column_list()
+
+        if not case_sensitive_colnames:
+            this_column_list = [col.lower() for col in self.get_column_list()]
+            other_column_list = [col.lower() for col in other.get_column_list()]
+        else:
+            this_column_list = self.get_column_list()
+            other_column_list = other.get_column_list()
 
         # Iteratively move through the columns in `this_column_list` and determine if:
         # - the column is present in `other_column_list`
@@ -335,7 +352,9 @@ class Schema:
 
         return True
 
-    def _compare_schema_columns_subset_any_order(self, other: Schema) -> bool:
+    def _compare_schema_columns_subset_any_order(
+        self, other: Schema, case_sensitive_colnames: bool, case_sensitive_dtypes: bool
+    ) -> bool:
         """
         Compare the columns of the schema with another schema to ensure that all column names are
         at least in the other schema. Column order is not considered here. This method is performed
@@ -354,8 +373,13 @@ class Schema:
         bool
             True if the columns are the same, False otherwise.
         """
-        this_column_list = self.get_column_list()
-        other_column_list = other.get_column_list()
+
+        if not case_sensitive_colnames:
+            this_column_list = [col.lower() for col in self.get_column_list()]
+            other_column_list = [col.lower() for col in other.get_column_list()]
+        else:
+            this_column_list = self.get_column_list()
+            other_column_list = other.get_column_list()
 
         # Iteratively move through the columns in `this_column_list` and determine if:
         # - the column is present in `other_column_list`

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -190,14 +190,13 @@ class Schema:
                 "The provided table object cannot be converted to a Narwhals DataFrame."
             )
 
-    def _compare_schema_columns_subset_any_order(self, other: Schema) -> bool:
+    def _compare_schema_columns_complete_in_order(self, other: Schema) -> bool:
         """
-        Compare the columns of the schema with another schema to ensure that all column names are
-        at least in the other schema. Column order is not considered here. This method is performed
-        when:
+        Compare the columns of the schema with another schema. Ensure that all column names are the
+        same and that they are in the same order. This method is performed when:
 
-        - `complete`: False
-        - `in_order`: False
+        - `complete`: True
+        - `in_order`: True
 
         Parameters
         ----------
@@ -212,11 +211,19 @@ class Schema:
         this_column_list = self.get_column_list()
         other_column_list = other.get_column_list()
 
+        # Check if the column lists are the same length, this is a quick check to determine
+        # if the schemas are different
+        if len(this_column_list) != len(other_column_list):
+            return False
+
+        # Check that the column names are the same in both schemas
+        if this_column_list != other_column_list:
+            return False
+
         # Iteratively move through the columns in `this_column_list` and determine if:
-        # - the column is present in `other_column_list`
+        # - the column is present in `other_column_list` at the same index
         # - the dtype of the column in `this_column_list` is the same as the dtype in
         #   `other_column_list`
-
         for col in this_column_list:
             if col not in other_column_list:
                 return False
@@ -277,52 +284,6 @@ class Schema:
 
         return True
 
-    def _compare_schema_columns_complete_in_order(self, other: Schema) -> bool:
-        """
-        Compare the columns of the schema with another schema. Ensure that all column names are the
-        same and that they are in the same order. This method is performed when:
-
-        - `complete`: True
-        - `in_order`: True
-
-        Parameters
-        ----------
-        other
-            The other schema to compare against.
-
-        Returns
-        -------
-        bool
-            True if the columns are the same, False otherwise.
-        """
-        this_column_list = self.get_column_list()
-        other_column_list = other.get_column_list()
-
-        # Check if the column lists are the same length, this is a quick check to determine
-        # if the schemas are different
-        if len(this_column_list) != len(other_column_list):
-            return False
-
-        # Check that the column names are the same in both schemas
-        if this_column_list != other_column_list:
-            return False
-
-        # Iteratively move through the columns in `this_column_list` and determine if:
-        # - the column is present in `other_column_list` at the same index
-        # - the dtype of the column in `this_column_list` is the same as the dtype in
-        #   `other_column_list`
-        for col in this_column_list:
-            if col not in other_column_list:
-                return False
-            else:
-                this_dtype = self.columns[this_column_list.index(col)][1]
-                other_dtype = other.columns[other_column_list.index(col)][1]
-
-                if this_dtype != other_dtype:
-                    return False
-
-        return True
-
     def _compare_schema_columns_subset_in_order(self, other: Schema) -> bool:
         """
         Compare the columns of the schema with another schema. Ensure that all column names in the
@@ -371,6 +332,45 @@ class Schema:
 
         if this_column_list != other_column_list_subset:
             return False
+
+        return True
+
+    def _compare_schema_columns_subset_any_order(self, other: Schema) -> bool:
+        """
+        Compare the columns of the schema with another schema to ensure that all column names are
+        at least in the other schema. Column order is not considered here. This method is performed
+        when:
+
+        - `complete`: False
+        - `in_order`: False
+
+        Parameters
+        ----------
+        other
+            The other schema to compare against.
+
+        Returns
+        -------
+        bool
+            True if the columns are the same, False otherwise.
+        """
+        this_column_list = self.get_column_list()
+        other_column_list = other.get_column_list()
+
+        # Iteratively move through the columns in `this_column_list` and determine if:
+        # - the column is present in `other_column_list`
+        # - the dtype of the column in `this_column_list` is the same as the dtype in
+        #   `other_column_list`
+
+        for col in this_column_list:
+            if col not in other_column_list:
+                return False
+            else:
+                this_dtype = self.columns[this_column_list.index(col)][1]
+                other_dtype = other.columns[other_column_list.index(col)][1]
+
+                if this_dtype != other_dtype:
+                    return False
 
         return True
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2587,6 +2587,8 @@ class Validate:
         schema: Schema,
         complete: bool = True,
         in_order: bool = True,
+        case_sensitive_colnames: bool = True,
+        case_sensitive_dtypes: bool = True,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
         active: bool = True,
@@ -2613,6 +2615,14 @@ class Validate:
             Should the schema match be in order? If `True`, then the columns in the schema must
             appear in the same order as they do in the target table. If `False`, then the order of
             columns in the schema and the target table can differ.
+        case_sensitive_colnames
+            Should the schema match be case-sensitive with regard to column names? If `True`, then
+            the column names in the schema and the target table must match exactly. If `False`, then
+            the column names are compared in a case-insensitive manner.
+        case_sensitive_dtypes
+            Should the schema match be case-sensitive with regard to column data types? If `True`,
+            then the column data types in the schema and the target table must match exactly. If
+            `False`, then the column data types are compared in a case-insensitive manner.
         pre
             A pre-processing function or lambda to apply to the data table for the validation step.
         thresholds
@@ -2697,14 +2707,24 @@ class Validate:
         _check_pre(pre=pre)
         _check_thresholds(thresholds=thresholds)
         _check_boolean_input(param=active, param_name="active")
+        _check_boolean_input(param=complete, param_name="complete")
+        _check_boolean_input(param=in_order, param_name="in_order")
+        _check_boolean_input(param=case_sensitive_colnames, param_name="case_sensitive_colnames")
+        _check_boolean_input(param=case_sensitive_dtypes, param_name="case_sensitive_dtypes")
 
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
             self.thresholds if thresholds is None else _normalize_thresholds_creation(thresholds)
         )
 
-        # Package up schema, complete, and in_order into a dictionary for the validation step
-        values = {"schema": schema, "complete": complete, "in_order": in_order}
+        # Package up the `schema=` and boolean params into a dictionary for later interrogation
+        values = {
+            "schema": schema,
+            "complete": complete,
+            "in_order": in_order,
+            "case_sensitive_colnames": case_sensitive_colnames,
+            "case_sensitive_dtypes": case_sensitive_dtypes,
+        }
 
         val_info = _ValidationInfo(
             assertion_type=assertion_type,

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -3020,6 +3020,8 @@ class Validate:
                     schema=value["schema"],
                     complete=value["complete"],
                     in_order=value["in_order"],
+                    case_sensitive_colnames=value["case_sensitive_colnames"],
+                    case_sensitive_dtypes=value["case_sensitive_dtypes"],
                     threshold=threshold,
                 ).get_test_results()
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1686,7 +1686,7 @@ def test_col_schema_match():
     assert (
         Validate(data=tbl)
         .col_schema_match(
-            schema=schema, in_order=False, complete=True, case_sensitive_colnames=False
+            schema=schema, complete=True, in_order=False, case_sensitive_colnames=False
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1695,7 +1695,7 @@ def test_col_schema_match():
     assert (
         Validate(data=tbl)
         .col_schema_match(
-            schema=schema, in_order=False, complete=True, case_sensitive_colnames=False
+            schema=schema, complete=False, in_order=True, case_sensitive_colnames=False
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1704,7 +1704,7 @@ def test_col_schema_match():
     assert (
         Validate(data=tbl)
         .col_schema_match(
-            schema=schema, in_order=False, complete=False, case_sensitive_colnames=False
+            schema=schema, complete=False, in_order=False, case_sensitive_colnames=False
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1722,14 +1722,14 @@ def test_col_schema_match():
     )
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, in_order=False, complete=True, case_sensitive_dtypes=False)
+        .col_schema_match(schema=schema, complete=True, in_order=False, case_sensitive_dtypes=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 1
     )
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, in_order=False, complete=True, case_sensitive_dtypes=False)
+        .col_schema_match(schema=schema, complete=False, in_order=True, case_sensitive_dtypes=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 1
@@ -1737,7 +1737,7 @@ def test_col_schema_match():
     assert (
         Validate(data=tbl)
         .col_schema_match(
-            schema=schema, in_order=False, complete=False, case_sensitive_dtypes=False
+            schema=schema, complete=False, in_order=False, case_sensitive_dtypes=False
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1758,8 +1758,8 @@ def test_col_schema_match():
         Validate(data=tbl)
         .col_schema_match(
             schema=schema,
-            in_order=False,
             complete=True,
+            in_order=False,
             case_sensitive_colnames=False,
             case_sensitive_dtypes=False,
         )
@@ -1771,21 +1771,21 @@ def test_col_schema_match():
         Validate(data=tbl)
         .col_schema_match(
             schema=schema,
-            in_order=False,
-            complete=True,
-            case_sensitive_colnames=False,
-            case_sensitive_dtypes=False,
-        )
-        .interrogate()
-        .n_passed(i=1, scalar=True)
-        == 1
-    )
-    assert (
-        Validate(data=tbl)
-        .col_schema_match(
-            schema=schema,
-            in_order=False,
             complete=False,
+            in_order=True,
+            case_sensitive_colnames=False,
+            case_sensitive_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=False,
             case_sensitive_colnames=False,
             case_sensitive_dtypes=False,
         )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1712,10 +1712,24 @@ def test_col_schema_match():
     )
 
     # Completely correct schema supplied to `columns=` except for the case mismatch in dtypes
-    schema = Schema(columns=[("a", "String"), ("b", "Int64"), ("c", "Float64")])
+    schema = Schema(columns=[("a", "string"), ("b", "INT64"), ("c", "FloaT64")])
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, case_sensitive_colnames=False)
+        .col_schema_match(schema=schema, case_sensitive_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True, case_sensitive_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True, case_sensitive_dtypes=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 1
@@ -1723,7 +1737,31 @@ def test_col_schema_match():
     assert (
         Validate(data=tbl)
         .col_schema_match(
-            schema=schema, in_order=False, complete=True, case_sensitive_colnames=False
+            schema=schema, in_order=False, complete=False, case_sensitive_dtypes=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Completely correct schema supplied to `columns=` except for the case mismatch in
+    # colnames and dtypes
+    schema = Schema(columns=[("A", "string"), ("b", "INT64"), ("C", "FloaT64")])
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_colnames=False, case_sensitive_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            in_order=False,
+            complete=True,
+            case_sensitive_colnames=False,
+            case_sensitive_dtypes=False,
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1732,7 +1770,11 @@ def test_col_schema_match():
     assert (
         Validate(data=tbl)
         .col_schema_match(
-            schema=schema, in_order=False, complete=True, case_sensitive_colnames=False
+            schema=schema,
+            in_order=False,
+            complete=True,
+            case_sensitive_colnames=False,
+            case_sensitive_dtypes=False,
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1741,7 +1783,11 @@ def test_col_schema_match():
     assert (
         Validate(data=tbl)
         .col_schema_match(
-            schema=schema, in_order=False, complete=False, case_sensitive_colnames=False
+            schema=schema,
+            in_order=False,
+            complete=False,
+            case_sensitive_colnames=False,
+            case_sensitive_dtypes=False,
         )
         .interrogate()
         .n_passed(i=1, scalar=True)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1674,6 +1674,80 @@ def test_col_schema_match():
         == 0
     )
 
+    # Completely correct schema supplied to `columns=` except for the case mismatch in colnames
+    schema = Schema(columns=[("a", "String"), ("B", "Int64"), ("C", "Float64")])
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_colnames=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, in_order=False, complete=True, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, in_order=False, complete=True, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, in_order=False, complete=False, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Completely correct schema supplied to `columns=` except for the case mismatch in dtypes
+    schema = Schema(columns=[("a", "String"), ("b", "Int64"), ("c", "Float64")])
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_colnames=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, in_order=False, complete=True, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, in_order=False, complete=True, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, in_order=False, complete=False, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
 
 @pytest.mark.parametrize("tbl_fixture", TBL_DATES_TIMES_TEXT_LIST)
 def test_interrogate_first_n(request, tbl_fixture):


### PR DESCRIPTION
This PR adds the `case_sensitive_colnames=` and `case_sensitive_dtypes=` arguments to the `col_schema_match()` validation method. Both are set to `True` by default, which doesn't change the previous behavior. Setting any of these to `False` performs a case-insensitive match during interrogation.

The most important changes include updates to the `ColSchemaMatch` class, the schema comparison methods, and the `col_schema_match()` method, as well as new test cases to ensure the correctness of these features.

Enhancements to schema matching:

* [`pointblank/_interrogation.py`]: Added `case_sensitive_colnames` and `case_sensitive_dtypes` parameters to the `ColSchemaMatch` class and updated the `__post_init__` method to handle these parameters.

Updates to schema comparison methods:

* [`pointblank/schema.py`]: Modified schema comparison methods (`_compare_schema_columns_complete_in_order`, `_compare_schema_columns_subset_any_order`, etc.) to include `case_sensitive_colnames` and `case_sensitive_dtypes` parameters.

Enhancements to the `col_schema_match()` method:

* [`pointblank/validate.py`]: Added `case_sensitive_colnames=` and `case_sensitive_dtypes=` parameters to the `col_schema_match` function and updated the validation logic to handle these parameters.

New test cases:

* [`tests/test_validate.py`]: Added new test cases to verify the functionality of the `col_schema_match()` method with different combinations of case sensitivity settings for column names and data types.