### PR TITLE
fix: display empty validation reports when there are no validation steps

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -4351,6 +4351,143 @@ class Validate:
         # Get the thresholds object
         thresholds = self.thresholds
 
+        # Determine if there are any validation steps
+        no_validation_steps = len(self.validation_info) == 0
+
+        # If there are no steps, prepare a fairly empty table with a message indicating that there
+        # are no validation steps
+        if no_validation_steps:
+
+            # Create the title text
+            title_text = _get_title_text(
+                title=title, tbl_name=self.tbl_name, interrogation_performed=False
+            )
+
+            # Create the label, table type, and thresholds HTML fragments
+            label_html = _create_label_html(label=self.label, start_time="")
+            table_type_html = _create_table_type_html(tbl_type=tbl_info, tbl_name=self.tbl_name)
+            thresholds_html = _create_thresholds_html(thresholds=thresholds)
+
+            # Compose the subtitle HTML fragment
+            combined_subtitle = (
+                "<div>"
+                f"{label_html}"
+                '<div style="padding-top: 10px; padding-bottom: 5px;">'
+                f"{table_type_html}"
+                f"{thresholds_html}"
+                "</div>"
+                "</div>"
+            )
+
+            df = df_lib.DataFrame(
+                {
+                    "status_color": "",
+                    "i": "",
+                    "type_upd": "NO VALIDATION STEPS",
+                    "columns_upd": "",
+                    "values_upd": "",
+                    "tbl": "",
+                    "eval": "",
+                    "test_units": "",
+                    "pass": "",
+                    "fail": "",
+                    "w_upd": "",
+                    "s_upd": "",
+                    "n_upd": "",
+                    "extract_upd": "",
+                }
+            )
+
+            gt_tbl = (
+                GT(df, id="pb_tbl")
+                .fmt_markdown(columns=["pass", "fail", "extract_upd"])
+                .opt_table_font(font=google_font(name="IBM Plex Sans"))
+                .opt_align_table_header(align="left")
+                .tab_style(style=style.css("height: 20px;"), locations=loc.body())
+                .tab_style(
+                    style=style.text(weight="bold", color="#666666"), locations=loc.column_labels()
+                )
+                .tab_style(
+                    style=style.text(size="28px", weight="bold", align="left", color="#444444"),
+                    locations=loc.title(),
+                )
+                .tab_style(
+                    style=[style.fill(color="#FED8B1"), style.text(weight="bold")],
+                    locations=loc.body(),
+                )
+                .cols_label(
+                    cases={
+                        "status_color": "",
+                        "i": "",
+                        "type_upd": "STEP",
+                        "columns_upd": "COLUMNS",
+                        "values_upd": "VALUES",
+                        "tbl": "TBL",
+                        "eval": "EVAL",
+                        "test_units": "UNITS",
+                        "pass": "PASS",
+                        "fail": "FAIL",
+                        "w_upd": "W",
+                        "s_upd": "S",
+                        "n_upd": "N",
+                        "extract_upd": "EXT",
+                    }
+                )
+                .cols_width(
+                    cases={
+                        "status_color": "4px",
+                        "i": "35px",
+                        "type_upd": "190px",
+                        "columns_upd": "120px",
+                        "values_upd": "120px",
+                        "tbl": "50px",
+                        "eval": "50px",
+                        "test_units": "60px",
+                        "pass": "60px",
+                        "fail": "60px",
+                        "w_upd": "30px",
+                        "s_upd": "30px",
+                        "n_upd": "30px",
+                        "extract_upd": "65px",
+                    }
+                )
+                .cols_align(
+                    align="center",
+                    columns=["tbl", "eval", "w_upd", "s_upd", "n_upd", "extract_upd"],
+                )
+                .cols_align(align="right", columns=["test_units", "pass", "fail"])
+                .cols_move_to_start(
+                    [
+                        "status_color",
+                        "i",
+                        "type_upd",
+                        "columns_upd",
+                        "values_upd",
+                        "tbl",
+                        "eval",
+                        "test_units",
+                        "pass",
+                        "fail",
+                        "w_upd",
+                        "s_upd",
+                        "n_upd",
+                        "extract_upd",
+                    ]
+                )
+                .tab_options(table_font_size="90%")
+                .tab_source_note(
+                    source_note=html(
+                        "Use validation methods (like <code>col_vals_gt()</code>) to add"
+                        " steps to the validation plan."
+                    )
+                )
+            )
+
+            if incl_header:
+                gt_tbl = gt_tbl.tab_header(title=html(title_text), subtitle=html(combined_subtitle))
+
+            return gt_tbl
+
         # Convert the `validation_info` object to a dictionary
         validation_info_dict = _validation_info_as_dict(validation_info=self.validation_info)
 

--- a/tests/snapshots/test_validate/test_no_steps_validation_report_html_snap/no_steps_validation_report.html
+++ b/tests/snapshots/test_validate/test_no_steps_validation_report_html_snap/no_steps_validation_report.html
@@ -1,0 +1,122 @@
+<div id="pb_tbl" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<style>
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans&display=swap');
+#pb_tbl table {
+          font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+          -webkit-font-smoothing: antialiased;
+          -moz-osx-font-smoothing: grayscale;
+        }
+
+#pb_tbl thead, tbody, tfoot, tr, td, th { border-style: none; }
+ tr { background-color: transparent; }
+#pb_tbl p { margin: 0; padding: 0; }
+ #pb_tbl .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 90%; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
+ #pb_tbl .gt_caption { padding-top: 4px; padding-bottom: 4px; }
+ #pb_tbl .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
+ #pb_tbl .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 3px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; border-top-color: #FFFFFF; border-top-width: 0; }
+ #pb_tbl .gt_heading { background-color: #FFFFFF; text-align: left; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #pb_tbl .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #pb_tbl .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #pb_tbl .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; overflow-x: hidden; }
+ #pb_tbl .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
+ #pb_tbl .gt_column_spanner_outer:first-child { padding-left: 0; }
+ #pb_tbl .gt_column_spanner_outer:last-child { padding-right: 0; }
+ #pb_tbl .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; overflow-x: hidden; display: inline-block; width: 100%; }
+ #pb_tbl .gt_spanner_row { border-bottom-style: hidden; }
+ #pb_tbl .gt_group_heading { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
+ #pb_tbl .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
+ #pb_tbl .gt_from_md> :first-child { margin-top: 0; }
+ #pb_tbl .gt_from_md> :last-child { margin-bottom: 0; }
+ #pb_tbl .gt_row { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
+ #pb_tbl .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
+ #pb_tbl .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
+ #pb_tbl .gt_row_group_first td { border-top-width: 2px; }
+ #pb_tbl .gt_row_group_first th { border-top-width: 2px; }
+ #pb_tbl .gt_striped { background-color: rgba(128,128,128,0.05); }
+ #pb_tbl .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #pb_tbl .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
+ #pb_tbl .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
+ #pb_tbl .gt_left { text-align: left; }
+ #pb_tbl .gt_center { text-align: center; }
+ #pb_tbl .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
+ #pb_tbl .gt_font_normal { font-weight: normal; }
+ #pb_tbl .gt_font_bold { font-weight: bold; }
+ #pb_tbl .gt_font_italic { font-style: italic; }
+ #pb_tbl .gt_super { font-size: 65%; }
+ #pb_tbl .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
+ #pb_tbl .gt_asterisk { font-size: 100%; vertical-align: 0; }
+ 
+</style>
+<table style="table-layout: fixed;; width: 0px" class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
+<colgroup>
+  <col style="width:4px;"/>
+  <col style="width:35px;"/>
+  <col style="width:190px;"/>
+  <col style="width:120px;"/>
+  <col style="width:120px;"/>
+  <col style="width:50px;"/>
+  <col style="width:50px;"/>
+  <col style="width:60px;"/>
+  <col style="width:60px;"/>
+  <col style="width:60px;"/>
+  <col style="width:30px;"/>
+  <col style="width:30px;"/>
+  <col style="width:30px;"/>
+  <col style="width:65px;"/>
+</colgroup>
+
+<thead>
+
+  <tr class="gt_heading">
+    <td colspan="14" class="gt_heading gt_title gt_font_normal" style="color: #444444;font-size: 28px;text-align: left;font-weight: bold;"><div><span style="float: left;">Pointblank Validation</span><span style="float: right; text-decoration-line: underline; text-underline-position: under;font-size: 16px; text-decoration-color: #9C2E83;padding-top: 0.1em; padding-right: 0.4em;">No Interrogation Peformed</span></div></td>
+  </tr>
+  <tr class="gt_heading">
+    <td colspan="14" class="gt_heading gt_subtitle gt_font_normal gt_bottom_border"><div><span style='text-decoration-style: solid; text-decoration-color: #ADD8E6; text-decoration-line: underline; text-underline-position: under; color: #333333; font-variant-numeric: tabular-nums; padding-left: 4px; margin-right: 5px; padding-right: 2px;'></span><div style="padding-top: 10px; padding-bottom: 5px;"><span style='background-color: #0075FF; color: #FFFFFF; padding: 0.5em 0.5em; position: inherit; text-transform: uppercase; margin: 5px 0px 5px 0px; border: solid 1px #0075FF; font-weight: bold; padding: 2px 15px 2px 15px; font-size: smaller;'>Polars</span><span style='background-color: none; color: #222222; padding: 0.5em 0.5em; position: inherit; margin: 5px 10px 5px -4px; border: solid 1px #0075FF; font-weight: bold; padding: 2px 15px 2px 15px; font-size: smaller;'>small_table</span><span><span style="background-color: #E5AB00; color: white; padding: 0.5em 0.5em; position: inherit; text-transform: uppercase; margin: 5px 0px 5px 5px; border: solid 1px #E5AB00; font-weight: bold; padding: 2px 15px 2px 15px; font-size: smaller;">WARN</span><span style="background-color: none; color: #333333; padding: 0.5em 0.5em; position: inherit; margin: 5px 0px 5px -4px; font-weight: bold; border: solid 1px #E5AB00; padding: 2px 15px 2px 15px; font-size: smaller; margin-right: 5px;">0.1</span><span style="background-color: #D0182F; color: white; padding: 0.5em 0.5em; position: inherit; text-transform: uppercase; margin: 5px 0px 5px 1px; border: solid 1px #D0182F; font-weight: bold; padding: 2px 15px 2px 15px; font-size: smaller;">STOP</span><span style="background-color: none; color: #333333; padding: 0.5em 0.5em; position: inherit; margin: 5px 0px 5px -4px; font-weight: bold; border: solid 1px #D0182F; padding: 2px 15px 2px 15px; font-size: smaller; margin-right: 5px;">0.25</span><span style="background-color: #499FFE; color: white; padding: 0.5em 0.5em; position: inherit; text-transform: uppercase; margin: 5px 0px 5px 1px; border: solid 1px #499FFE; font-weight: bold; padding: 2px 15px 2px 15px; font-size: smaller;">NOTIFY</span><span style="background-color: none; color: #333333; padding: 0.5em 0.5em; position: inherit; margin: 5px 0px 5px -4px; font-weight: bold; border: solid 1px #499FFE; padding: 2px 15px 2px 15px; font-size: smaller;">0.35</span></span></div></div></td>
+  </tr>
+<tr class="gt_col_headings">
+  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id=""></th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id=""></th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="STEP">STEP</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="COLUMNS">COLUMNS</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="VALUES">VALUES</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="TBL">TBL</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="EVAL">EVAL</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="UNITS">UNITS</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="PASS">PASS</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="FAIL">FAIL</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="W">W</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="S">S</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="N">N</th>
+  <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" style="color: #666666;font-weight: bold;" scope="col" id="EXT">EXT</th>
+</tr>
+</thead>
+<tbody class="gt_table_body">
+  <tr>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_left"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_left"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_left">NO VALIDATION STEPS</td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_left"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_left"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_center"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_center"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_right"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_right"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_right"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_center"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_center"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_center"></td>
+    <td style="height: 20px; background-color: #FED8B1; font-weight: bold;" class="gt_row gt_center"></td>
+  </tr>
+</tbody>
+  <tfoot class="gt_sourcenotes">
+  
+  <tr>
+    <td class="gt_sourcenote" colspan="14">Use validation methods (like <code>col_vals_gt()</code>) to add steps to the validation plan.</td>
+  </tr>
+
+</tfoot>
+
+</table>
+
+</div>
+        

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -552,6 +552,15 @@ def test_validation_report_use_fields_snap(request, tbl_fixture, snapshot):
 
 
 @pytest.mark.parametrize("tbl_fixture", TBL_LIST)
+def test_validation_report_json_no_steps(request, tbl_fixture):
+
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    assert Validate(tbl).get_json_report() == "[]"
+    assert Validate(tbl).interrogate().get_json_report() == "[]"
+
+
+@pytest.mark.parametrize("tbl_fixture", TBL_LIST)
 def test_validation_check_column_input(request, tbl_fixture):
 
     tbl = request.getfixturevalue(tbl_fixture)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2236,6 +2236,34 @@ def test_no_interrogation_validation_report_html_snap(snapshot):
     snapshot.assert_match(edited_report_html_str, "no_interrogation_validation_report.html")
 
 
+def test_no_steps_validation_report_html_snap(snapshot):
+
+    validation = Validate(
+        data=load_dataset(),
+        tbl_name="small_table",
+        thresholds=Thresholds(warn_at=0.10, stop_at=0.25, notify_at=0.35),
+    )
+
+    html_str = validation.get_tabular_report().as_raw_html()
+
+    # Use the snapshot fixture to create and save the snapshot
+    snapshot.assert_match(html_str, "no_steps_validation_report.html")
+
+
+def test_no_steps_validation_report_html_with_interrogate():
+
+    validation = Validate(
+        data=load_dataset(),
+        tbl_name="small_table",
+        thresholds=Thresholds(warn_at=0.10, stop_at=0.25, notify_at=0.35),
+    )
+
+    assert (
+        validation.interrogate().get_tabular_report().as_raw_html()
+        == validation.get_tabular_report().as_raw_html()
+    )
+
+
 def test_load_dataset():
 
     # Load the default dataset (`small_table`) and verify it's a Polars DataFrame


### PR DESCRIPTION
This PR introduces several changes to handle scenarios where there are no validation steps in a validation plan. The main changes include updates to the `get_tabular_report()` method, new test cases, and corresponding HTML snapshot updates.

Handling no validation steps:

* [`pointblank/validate.py`]: Added logic to handle cases where there are no validation steps, including creating a message and an empty table with appropriate formatting.

Test cases:

* [`tests/test_validate.py`]: Added a new test `test_no_steps_validation_report_html_snap` to validate the HTML report output when there are no validation steps.
* [`tests/test_validate.py`]: Added a new test `test_validation_report_json_no_steps` to check the JSON report output when there are no validation steps.

HTML snapshots:

* [`tests/snapshots/test_validate/test_no_steps_validation_report_html_snap/no_steps_validation_report.html`]: Added a new snapshot file to capture the HTML output for scenarios with no validation steps.

Fixes: #12 