### PR TITLE
feat: partial matching for dtypes

### DIFF
--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -1626,6 +1626,8 @@ class ColSchemaMatch:
         `True` to perform column-name matching in a case-sensitive manner, `False` otherwise.
     case_sensitive_dtypes
         `True` to perform data-type matching in a case-sensitive manner, `False` otherwise.
+    full_match_dytpes
+        `True` to perform a full match of data types, `False` otherwise.
     threshold
         The maximum number of failing test units to allow.
     tbl_type
@@ -1644,6 +1646,7 @@ class ColSchemaMatch:
     in_order: bool
     case_sensitive_colnames: bool
     case_sensitive_dtypes: bool
+    full_match_dytpes: bool
     threshold: int
 
     def __post_init__(self):
@@ -1658,6 +1661,7 @@ class ColSchemaMatch:
                 other=schema_actual,
                 case_sensitive_colnames=self.case_sensitive_colnames,
                 case_sensitive_dtypes=self.case_sensitive_dtypes,
+                full_match_dytpes=self.full_match_dytpes,
             )
 
         elif not self.complete and not self.in_order:
@@ -1667,6 +1671,7 @@ class ColSchemaMatch:
                 other=schema_actual,
                 case_sensitive_colnames=self.case_sensitive_colnames,
                 case_sensitive_dtypes=self.case_sensitive_dtypes,
+                full_match_dytpes=self.full_match_dytpes,
             )
 
         elif self.complete:
@@ -1676,6 +1681,7 @@ class ColSchemaMatch:
                 other=schema_actual,
                 case_sensitive_colnames=self.case_sensitive_colnames,
                 case_sensitive_dtypes=self.case_sensitive_dtypes,
+                full_match_dytpes=self.full_match_dytpes,
             )
 
         else:
@@ -1685,6 +1691,7 @@ class ColSchemaMatch:
                 other=schema_actual,
                 case_sensitive_colnames=self.case_sensitive_colnames,
                 case_sensitive_dtypes=self.case_sensitive_dtypes,
+                full_match_dytpes=self.full_match_dytpes,
             )
 
         self.test_unit_res = res

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -191,7 +191,11 @@ class Schema:
             )
 
     def _compare_schema_columns_complete_in_order(
-        self, other: Schema, case_sensitive_colnames: bool, case_sensitive_dtypes: bool
+        self,
+        other: Schema,
+        case_sensitive_colnames: bool,
+        case_sensitive_dtypes: bool,
+        full_match_dytpes: bool,
     ) -> bool:
         """
         Compare the columns of the schema with another schema. Ensure that all column names are the
@@ -238,13 +242,20 @@ class Schema:
                 this_dtype = this_dtype.lower()
                 other_dtype = other_dtype.lower()
 
-            if this_dtype != other_dtype:
+            if full_match_dytpes and this_dtype != other_dtype:
+                return False
+
+            if not full_match_dytpes and this_dtype not in other_dtype:
                 return False
 
         return True
 
     def _compare_schema_columns_complete_any_order(
-        self, other: Schema, case_sensitive_colnames: bool, case_sensitive_dtypes: bool
+        self,
+        other: Schema,
+        case_sensitive_colnames: bool,
+        case_sensitive_dtypes: bool,
+        full_match_dytpes: bool,
     ) -> bool:
         """
         Compare the columns of the schema with another schema to ensure that all column names are
@@ -297,13 +308,20 @@ class Schema:
                     this_dtype = this_dtype.lower()
                     other_dtype = other_dtype.lower()
 
-                if this_dtype != other_dtype:
+                if full_match_dytpes and this_dtype != other_dtype:
+                    return False
+
+                if not full_match_dytpes and this_dtype not in other_dtype:
                     return False
 
         return True
 
     def _compare_schema_columns_subset_in_order(
-        self, other: Schema, case_sensitive_colnames: bool, case_sensitive_dtypes: bool
+        self,
+        other: Schema,
+        case_sensitive_colnames: bool,
+        case_sensitive_dtypes: bool,
+        full_match_dytpes: bool,
     ) -> bool:
         """
         Compare the columns of the schema with another schema. Ensure that all column names in the
@@ -352,7 +370,10 @@ class Schema:
                     this_dtype = this_dtype.lower()
                     other_dtype = other_dtype.lower()
 
-                if this_dtype != other_dtype:
+                if full_match_dytpes and this_dtype != other_dtype:
+                    return False
+
+                if not full_match_dytpes and this_dtype not in other_dtype:
                     return False
 
         # With the subset of columns in `this_column_list`, ensure that the columns are in the same
@@ -365,7 +386,11 @@ class Schema:
         return True
 
     def _compare_schema_columns_subset_any_order(
-        self, other: Schema, case_sensitive_colnames: bool, case_sensitive_dtypes: bool
+        self,
+        other: Schema,
+        case_sensitive_colnames: bool,
+        case_sensitive_dtypes: bool,
+        full_match_dytpes: bool,
     ) -> bool:
         """
         Compare the columns of the schema with another schema to ensure that all column names are
@@ -409,7 +434,10 @@ class Schema:
                     this_dtype = this_dtype.lower()
                     other_dtype = other_dtype.lower()
 
-                if this_dtype != other_dtype:
+                if full_match_dytpes and this_dtype != other_dtype:
+                    return False
+
+                if not full_match_dytpes and this_dtype not in other_dtype:
                     return False
 
         return True

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2589,6 +2589,7 @@ class Validate:
         in_order: bool = True,
         case_sensitive_colnames: bool = True,
         case_sensitive_dtypes: bool = True,
+        full_match_dytpes: bool = True,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
         active: bool = True,
@@ -2623,6 +2624,11 @@ class Validate:
             Should the schema match be case-sensitive with regard to column data types? If `True`,
             then the column data types in the schema and the target table must match exactly. If
             `False`, then the column data types are compared in a case-insensitive manner.
+        full_match_dytpes
+            Should the schema match require a full match of data types? If `True`, then the column
+            data types in the schema and the target table must match exactly. If `False` then
+            substring matches are allowed, so a schema data type of `Int` would match a target table
+            data type of `Int64`.
         pre
             A pre-processing function or lambda to apply to the data table for the validation step.
         thresholds
@@ -2711,6 +2717,7 @@ class Validate:
         _check_boolean_input(param=in_order, param_name="in_order")
         _check_boolean_input(param=case_sensitive_colnames, param_name="case_sensitive_colnames")
         _check_boolean_input(param=case_sensitive_dtypes, param_name="case_sensitive_dtypes")
+        _check_boolean_input(param=full_match_dytpes, param_name="full_match_dytpes")
 
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
@@ -2724,6 +2731,7 @@ class Validate:
             "in_order": in_order,
             "case_sensitive_colnames": case_sensitive_colnames,
             "case_sensitive_dtypes": case_sensitive_dtypes,
+            "full_match_dytpes": full_match_dytpes,
         }
 
         val_info = _ValidationInfo(
@@ -3022,6 +3030,7 @@ class Validate:
                     in_order=value["in_order"],
                     case_sensitive_colnames=value["case_sensitive_colnames"],
                     case_sensitive_dtypes=value["case_sensitive_dtypes"],
+                    full_match_dytpes=value["full_match_dytpes"],
                     threshold=threshold,
                 ).get_test_results()
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1803,6 +1803,167 @@ def test_col_schema_match():
         == 1
     )
 
+    # Matching dtypes with substrings in the supplied schema (`full_match_dytpes=False` case)
+    schema = Schema(columns=[("a", "Str"), ("b", "Int"), ("c", "Float64")])
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, full_match_dytpes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=True, in_order=False, full_match_dytpes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=True, full_match_dytpes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=False, full_match_dytpes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Matching dtypes with substrings in the supplied schema (`full_match_dytpes=True` case)
+    schema = Schema(columns=[("a", "Str"), ("b", "Int"), ("c", "Float64")])
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, full_match_dytpes=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=True, in_order=False, full_match_dytpes=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=True, full_match_dytpes=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=False, full_match_dytpes=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Matching dtypes with substrings in the supplied schema and using case-insensitive matching
+    schema = Schema(columns=[("a", "str"), ("b", "Int"), ("c", "float64")])
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_dtypes=False, full_match_dytpes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=True,
+            in_order=False,
+            case_sensitive_dtypes=False,
+            full_match_dytpes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=True,
+            case_sensitive_dtypes=False,
+            full_match_dytpes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=False,
+            case_sensitive_dtypes=False,
+            full_match_dytpes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Matching dtypes with substrings in the supplied schema and using case-insensitive matching
+    # (`case_sensitive_dtypes=True` case)
+    schema = Schema(columns=[("a", "str"), ("b", "Int"), ("c", "float64")])
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_dtypes=True, full_match_dytpes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=True,
+            in_order=False,
+            case_sensitive_dtypes=True,
+            full_match_dytpes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=True,
+            case_sensitive_dtypes=True,
+            full_match_dytpes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=False,
+            case_sensitive_dtypes=True,
+            full_match_dytpes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
 
 @pytest.mark.parametrize("tbl_fixture", TBL_DATES_TIMES_TEXT_LIST)
 def test_interrogate_first_n(request, tbl_fixture):


### PR DESCRIPTION
This PR introduces the ability to perform substring matching on dtypes during schema validation (using `col_schema_match()`). The changes include updates to the schema validation logic, the addition of a new parameter `full_match_dytpes=` (default is `True`), and corresponding updates to the test cases.

