### PR TITLE
feat: within `col_schema_match()`, enable checks of columns only (exclusive of dtypes)

### DIFF
--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -247,6 +247,11 @@ class Schema:
         # the column in `this_column_list` is the same as the dtype in `other_column_list`
         for col in this_column_list:
 
+            # Skip dtype checks if the tuple value of `col` only contains the column name
+            # (i.e., is a single element tuple)
+            if len(self.columns[this_column_list.index(col)]) == 1:
+                continue
+
             this_dtype = self.columns[this_column_list.index(col)][1]
             other_dtype = other.columns[other_column_list.index(col)][1]
 
@@ -307,6 +312,12 @@ class Schema:
             if col not in other_column_list:
                 return False
             else:
+
+                # Skip dtype checks if the tuple value of `col` only contains the column name
+                # (i.e., is a single element tuple)
+                if len(self.columns[this_column_list.index(col)]) == 1:
+                    continue
+
                 this_dtype = self.columns[this_column_list.index(col)][1]
 
                 # The corresponding column in the other schema is present but not necessarily at
@@ -369,6 +380,12 @@ class Schema:
             if col not in other_column_list:
                 return False
             else:
+
+                # Skip dtype checks if the tuple value of `col` only contains the column name
+                # (i.e., is a single element tuple)
+                if len(self.columns[this_column_list.index(col)]) == 1:
+                    continue
+
                 this_dtype = self.columns[this_column_list.index(col)][1]
 
                 # The corresponding column in the other schema is present but not necessarily at
@@ -439,6 +456,12 @@ class Schema:
             if col not in other_column_list:
                 return False
             else:
+
+                # Skip dtype checks if the tuple value of `col` only contains the column name
+                # (i.e., is a single element tuple)
+                if len(self.columns[this_column_list.index(col)]) == 1:
+                    continue
+
                 this_dtype = self.columns[this_column_list.index(col)][1]
                 other_dtype = other.columns[other_column_list.index(col)][1]
 

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -563,7 +563,7 @@ class Schema:
 
 
 def _process_columns(
-    *, columns: list[tuple[str, str]] | dict[str, str] | None = None, **kwargs
+    *, columns: list[str] | list[tuple[str, str]] | dict[str, str] | None = None, **kwargs
 ) -> list[tuple[str, str]]:
     """
     Process column information provided as individual arguments or as a list of

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -16,24 +16,36 @@ __all__ = ["Schema"]
 class Schema:
     """Definition of a schema object.
 
-    The schema object defines the structure of a table, including the table name and its columns.
-    A schema for a table can be defined by adding column names and types for each of the columns
-    as tuples in a list, as a dictionary, or as individual keyword arguments. The schema object
-    can then be used to validate the structure of a table against the schema.
+    The schema object defines the structure of a table. Once it is defined, the object can be used
+    in a validation workflow, using `Validate` and its methods, to ensure that the structure of a
+    table matches the expected schema. The validation method that works with the schema object is
+    called `col_schema_match()`.
 
-    We can alternatively provide a DataFrame or Ibis table object and the schema will be collected
-    from either type of object. Note that if `tbl=` is provided then there shouldn't be any other
-    inputs provided through either `columns=` or `**kwargs`.
+    A schema for a table can be constructed with `Schema` in a number of ways:
+
+    1. providing a list of column names to `columns=` (to check only the column names)
+    2. using a list of two-element tuples in `columns=` (to check both column names and dtypes)
+    3. providing a dictionary to `columns=`, where the keys are column names and the values are
+    dtypes
+    4. providing individual column arguments in the form of keyword arguments (in the form of
+    `column=dtype`)
+
+    The schema object can also be constructed by providing a DataFrame or Ibis table object (using
+    the `tbl=` parameter) and the schema will be collected from either type of object. The schema
+    object can be printed to display the column names and dtypes. Note that if `tbl=` is provided
+    then there shouldn't be any other inputs provided through either `columns=` or `**kwargs`.
 
     Parameters
     ----------
     columns
-        A list of tuples or a dictionary containing column information. If provided, this will take
-        precedence over any individual column arguments provided via `**kwargs`.
+        A list of strings (representing column names), a list of tuples (for column names and column
+        dtypes), or a dictionary containing column and dtype information. If any of these inputs are
+        provided here, it will take precedence over any column arguments provided via `**kwargs`.
     tbl
         A DataFrame or Ibis table object from which the schema will be collected.
     **kwargs
-        Individual column arguments. These will be ignored if the `columns=` parameter is provided.
+        Individual column arguments that are in the form of `[column]=[dtype]`. These will be
+        ignored if the `columns=` parameter is not `None`.
 
     Examples
     --------

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -118,7 +118,7 @@ class Schema:
     validation passed.
     """
 
-    columns: list[tuple[str, str]] | None = None
+    columns: str | list[str] | list[tuple[str, str]] | None = None
     tbl: any | None = None
 
     def __init__(

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -582,6 +582,17 @@ def _process_columns(
         A list of tuples containing column information.
     """
     if columns is not None:
+
+        if isinstance(columns, list):
+
+            if all(isinstance(col, str) for col in columns):
+                return [(col,) for col in columns]
+            else:
+                return columns
+
+        if isinstance(columns, str):
+            return [(columns,)]
+
         if isinstance(columns, dict):
             return list(columns.items())
         return columns

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -50,7 +50,6 @@ def tbl_sqlite():
 
 
 def test_schema_str(capfd):
-
     schema = Schema(columns=[("a", "int"), ("b", "str")])
     print(schema)
     captured = capfd.readouterr()
@@ -68,6 +67,22 @@ def test_equivalent_inputs():
     schema_1 = Schema(columns=[("a", "int"), ("b", "str")])
     schema_2 = Schema(columns={"a": "int", "b": "str"})
     schema_3 = Schema(a="int", b="str")
+
+    assert schema_1.columns == schema_2.columns
+    assert schema_2.columns == schema_3.columns
+
+
+def test_schema_only_columns_equivalent_inputs():
+    schema_1 = Schema(columns=["a", "b"])
+    schema_2 = Schema(columns=[("a",), ("b",)])
+
+    assert schema_1.columns == schema_2.columns
+
+
+def test_schema_single_column_equivalent_inputs():
+    schema_1 = Schema(columns=["a"])
+    schema_2 = Schema(columns="a")
+    schema_3 = Schema(columns=[("a",)])
 
     assert schema_1.columns == schema_2.columns
     assert schema_2.columns == schema_3.columns

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1975,7 +1975,7 @@ def test_col_schema_match_columns_only():
         }
     )
 
-    # Completely correct schema supplied to `columns=`
+    # Completely correct schema supplied to `columns=` as a list of strings
     schema = Schema(columns=["a", "b", "c"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
@@ -2003,7 +2003,35 @@ def test_col_schema_match_columns_only():
         == 1
     )
 
-    # Schema expressed in a different order (yet complete)
+    # Completely correct schema supplied to `columns=` as a list of 1-element tuples
+    schema = Schema(columns=[("a",), ("b",), ("c",)])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Schema columns expressed in a different order (yet complete)
     schema = Schema(columns=["b", "c", "a"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
@@ -2031,7 +2059,7 @@ def test_col_schema_match_columns_only():
         == 0
     )
 
-    # Schema expressed in a different order (yet complete) - wrong column name
+    # Schema columns expressed in a different order (yet complete) - wrong column name
     schema = Schema(columns=["b", "c", "wrong"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
@@ -2059,7 +2087,7 @@ def test_col_schema_match_columns_only():
         == 0
     )
 
-    # Schema has duplicate column
+    # Schema of columns has a duplicate column
     schema = Schema(columns=["a", "a", "b", "c"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
@@ -2087,7 +2115,7 @@ def test_col_schema_match_columns_only():
         == 1
     )
 
-    # Schema has duplicate column/dtype - wrong column name
+    # Schema columns has duplicate column and a wrong column name
     schema = Schema(columns=["a", "a", "wrong", "c"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
@@ -2115,7 +2143,7 @@ def test_col_schema_match_columns_only():
         == 0
     )
 
-    # Supplied schema is a subset of the actual schema (in the correct order)
+    # Supplied columns are a subset of the actual columns (but in the correct order)
     schema = Schema(columns=["b", "c"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
@@ -2143,7 +2171,7 @@ def test_col_schema_match_columns_only():
         == 1
     )
 
-    # Supplied schema is a subset of the actual schema (in the correct order) - wrong column name
+    # Supplied columns are a subset of the actual column (in correct order) - has wrong column name
     schema = Schema(columns=["wrong", "c"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
@@ -2171,7 +2199,7 @@ def test_col_schema_match_columns_only():
         == 0
     )
 
-    # Supplied schema is a subset of the actual schema but in a different order
+    # Supplied columns are a subset of the actual schema but in a different order
     schema = Schema(columns=["c", "b"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
@@ -2199,7 +2227,7 @@ def test_col_schema_match_columns_only():
         == 1
     )
 
-    # Supplied schema is a subset of the actual schema but in a different order - wrong column name
+    # Supplied columns are a subset of actual columns but in a different order - wrong column name
     schema = Schema(columns=["wrong", "b"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
@@ -2227,7 +2255,7 @@ def test_col_schema_match_columns_only():
         == 0
     )
 
-    # Completely correct schema supplied to `columns=` except for the case mismatch in colnames
+    # Completely correct column names except for case mismatches
     schema = Schema(columns=["a", "B", "C"])
     assert (
         Validate(data=tbl)
@@ -2259,6 +2287,62 @@ def test_col_schema_match_columns_only():
         .col_schema_match(
             schema=schema, complete=False, in_order=False, case_sensitive_colnames=False
         )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Single (but correct) column supplied to `columns=` as a string
+    schema = Schema(columns="a")
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=True, in_order=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Single (but correct) column supplied to `columns=` as a tuple within a list
+    schema = Schema(columns=[("a",)])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=True, in_order=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 1

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1965,6 +1965,306 @@ def test_col_schema_match():
     )
 
 
+def test_col_schema_match_columns_only():
+
+    tbl = pl.DataFrame(
+        {
+            "a": ["apple", "banana", "cherry", "date"],
+            "b": [1, 6, 3, 5],
+            "c": [1.1, 2.2, 3.3, 4.4],
+        }
+    )
+
+    # Completely correct schema supplied to `columns=`
+    schema = Schema(columns=["a", "b", "c"])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Schema expressed in a different order (yet complete)
+    schema = Schema(columns=["b", "c", "a"])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Schema expressed in a different order (yet complete) - wrong column name
+    schema = Schema(columns=["b", "c", "wrong"])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Schema has duplicate column
+    schema = Schema(columns=["a", "a", "b", "c"])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Schema has duplicate column/dtype - wrong column name
+    schema = Schema(columns=["a", "a", "wrong", "c"])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Supplied schema is a subset of the actual schema (in the correct order)
+    schema = Schema(columns=["b", "c"])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Supplied schema is a subset of the actual schema (in the correct order) - wrong column name
+    schema = Schema(columns=["wrong", "c"])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Supplied schema is a subset of the actual schema but in a different order
+    schema = Schema(columns=["c", "b"])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Supplied schema is a subset of the actual schema but in a different order - wrong column name
+    schema = Schema(columns=["wrong", "b"])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Completely correct schema supplied to `columns=` except for the case mismatch in colnames
+    schema = Schema(columns=["a", "B", "C"])
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_colnames=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, complete=True, in_order=False, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, complete=False, in_order=True, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, complete=False, in_order=False, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+
 @pytest.mark.parametrize("tbl_fixture", TBL_DATES_TIMES_TEXT_LIST)
 def test_interrogate_first_n(request, tbl_fixture):
 


### PR DESCRIPTION
This pull request includes changes to the `Schema` class in the `pointblank/schema.py` file, enhancing its flexibility and functionality. The most important changes include updating the schema definition and validation methods, modifying the `_process_columns()` function, and adding new tests to ensure the correctness of the new functionality.

Enhancements to schema definition and validation:

* [`pointblank/schema.py`]: Updated the `Schema` class to support various ways of defining schemas, including lists of column names, tuples, and dictionaries. Improved the documentation to reflect these changes.
* [`pointblank/schema.py`]: Modified the `columns=` attribute to accept strings, lists of strings, lists of tuples, or `None`.

Functionality improvements:

* [`pointblank/schema.py`]: Enhanced the `_compare_schema_columns_*` methods to skip dtype checks when only column names are provided.
* [`pointblank/schema.py`]: Updated the `_process_columns()` function to handle different input formats, including strings and lists of strings.

Added new tests for the `col_schema_match()` method to cover various scenarios, ensuring the new schema definition and validation functionalities work as expected.
