### PR TITLE
feat: allow definition of multiple dtypes per column in `Schema` to facilitate multiple attempts at dtype matching

### DIFF
--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -1626,7 +1626,7 @@ class ColSchemaMatch:
         `True` to perform column-name matching in a case-sensitive manner, `False` otherwise.
     case_sensitive_dtypes
         `True` to perform data-type matching in a case-sensitive manner, `False` otherwise.
-    full_match_dytpes
+    full_match_dtypes
         `True` to perform a full match of data types, `False` otherwise.
     threshold
         The maximum number of failing test units to allow.
@@ -1646,7 +1646,7 @@ class ColSchemaMatch:
     in_order: bool
     case_sensitive_colnames: bool
     case_sensitive_dtypes: bool
-    full_match_dytpes: bool
+    full_match_dtypes: bool
     threshold: int
 
     def __post_init__(self):
@@ -1661,7 +1661,7 @@ class ColSchemaMatch:
                 other=schema_actual,
                 case_sensitive_colnames=self.case_sensitive_colnames,
                 case_sensitive_dtypes=self.case_sensitive_dtypes,
-                full_match_dytpes=self.full_match_dytpes,
+                full_match_dtypes=self.full_match_dtypes,
             )
 
         elif not self.complete and not self.in_order:
@@ -1671,7 +1671,7 @@ class ColSchemaMatch:
                 other=schema_actual,
                 case_sensitive_colnames=self.case_sensitive_colnames,
                 case_sensitive_dtypes=self.case_sensitive_dtypes,
-                full_match_dytpes=self.full_match_dytpes,
+                full_match_dtypes=self.full_match_dtypes,
             )
 
         elif self.complete:
@@ -1681,7 +1681,7 @@ class ColSchemaMatch:
                 other=schema_actual,
                 case_sensitive_colnames=self.case_sensitive_colnames,
                 case_sensitive_dtypes=self.case_sensitive_dtypes,
-                full_match_dytpes=self.full_match_dytpes,
+                full_match_dtypes=self.full_match_dtypes,
             )
 
         else:
@@ -1691,7 +1691,7 @@ class ColSchemaMatch:
                 other=schema_actual,
                 case_sensitive_colnames=self.case_sensitive_colnames,
                 case_sensitive_dtypes=self.case_sensitive_dtypes,
-                full_match_dytpes=self.full_match_dytpes,
+                full_match_dtypes=self.full_match_dtypes,
             )
 
         self.test_unit_res = res

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -237,7 +237,7 @@ class Schema:
         other: Schema,
         case_sensitive_colnames: bool,
         case_sensitive_dtypes: bool,
-        full_match_dytpes: bool,
+        full_match_dtypes: bool,
     ) -> bool:
         """
         Compare the columns of the schema with another schema. Ensure that all column names are the
@@ -298,10 +298,10 @@ class Schema:
                     this_dtype[i] = this_dtype[i].lower()
                     other_dtype = other_dtype.lower()
 
-                if full_match_dytpes and this_dtype[i] == other_dtype:
+                if full_match_dtypes and this_dtype[i] == other_dtype:
                     dtype_matches.append(True)
 
-                if not full_match_dytpes and this_dtype[i] in other_dtype:
+                if not full_match_dtypes and this_dtype[i] in other_dtype:
                     dtype_matches.append(True)
 
             # If there are no matches for any of the dtypes provided, return False
@@ -315,7 +315,7 @@ class Schema:
         other: Schema,
         case_sensitive_colnames: bool,
         case_sensitive_dtypes: bool,
-        full_match_dytpes: bool,
+        full_match_dtypes: bool,
     ) -> bool:
         """
         Compare the columns of the schema with another schema to ensure that all column names are
@@ -383,10 +383,10 @@ class Schema:
                         this_dtype[i] = this_dtype[i].lower()
                         other_dtype = other_dtype.lower()
 
-                    if full_match_dytpes and this_dtype[i] == other_dtype:
+                    if full_match_dtypes and this_dtype[i] == other_dtype:
                         dtype_matches.append(True)
 
-                    if not full_match_dytpes and this_dtype[i] in other_dtype:
+                    if not full_match_dtypes and this_dtype[i] in other_dtype:
                         dtype_matches.append(True)
 
                 # If there are no matches for any of the dtypes provided, return False
@@ -400,7 +400,7 @@ class Schema:
         other: Schema,
         case_sensitive_colnames: bool,
         case_sensitive_dtypes: bool,
-        full_match_dytpes: bool,
+        full_match_dtypes: bool,
     ) -> bool:
         """
         Compare the columns of the schema with another schema. Ensure that all column names in the
@@ -464,10 +464,10 @@ class Schema:
                         this_dtype[i] = this_dtype[i].lower()
                         other_dtype = other_dtype.lower()
 
-                    if full_match_dytpes and this_dtype[i] == other_dtype:
+                    if full_match_dtypes and this_dtype[i] == other_dtype:
                         dtype_matches.append(True)
 
-                    if not full_match_dytpes and this_dtype[i] in other_dtype:
+                    if not full_match_dtypes and this_dtype[i] in other_dtype:
                         dtype_matches.append(True)
 
                 # If there are no matches for any of the dtypes provided, return False
@@ -488,7 +488,7 @@ class Schema:
         other: Schema,
         case_sensitive_colnames: bool,
         case_sensitive_dtypes: bool,
-        full_match_dytpes: bool,
+        full_match_dtypes: bool,
     ) -> bool:
         """
         Compare the columns of the schema with another schema to ensure that all column names are
@@ -546,10 +546,10 @@ class Schema:
                         this_dtype[i] = this_dtype[i].lower()
                         other_dtype = other_dtype.lower()
 
-                    if full_match_dytpes and this_dtype[i] == other_dtype:
+                    if full_match_dtypes and this_dtype[i] == other_dtype:
                         dtype_matches.append(True)
 
-                    if not full_match_dytpes and this_dtype[i] in other_dtype:
+                    if not full_match_dtypes and this_dtype[i] in other_dtype:
                         dtype_matches.append(True)
 
                 # If there are no matches for any of the dtypes provided, return False

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -21,14 +21,15 @@ class Schema:
     table matches the expected schema. The validation method that works with the schema object is
     called `col_schema_match()`.
 
-    A schema for a table can be constructed with `Schema` in a number of ways:
+    A schema for a table can be constructed with the `Schema` class in a number of ways:
 
     1. providing a list of column names to `columns=` (to check only the column names)
-    2. using a list of two-element tuples in `columns=` (to check both column names and dtypes)
+    2. using a list of two-element tuples in `columns=` (to check both column names and dtypes,
+    should be in the form of `[(column_name, dtype), ...]`)
     3. providing a dictionary to `columns=`, where the keys are column names and the values are
     dtypes
-    4. providing individual column arguments in the form of keyword arguments (in the form of
-    `column=dtype`)
+    4. providing individual column arguments in the form of keyword arguments (constructed as
+    `column_name=dtype`)
 
     The schema object can also be constructed by providing a DataFrame or Ibis table object (using
     the `tbl=` parameter) and the schema will be collected from either type of object. The schema

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -285,14 +285,27 @@ class Schema:
             this_dtype = self.columns[this_column_list.index(col)][1]
             other_dtype = other.columns[other_column_list.index(col)][1]
 
-            if not case_sensitive_dtypes:
-                this_dtype = this_dtype.lower()
-                other_dtype = other_dtype.lower()
+            # There may be multiple dtypes for a column, so we need to promote scalar dtypes to
+            # lists before iterating through them
+            if isinstance(this_dtype, str):
+                this_dtype = [this_dtype]
 
-            if full_match_dytpes and this_dtype != other_dtype:
-                return False
+            dtype_matches = []
 
-            if not full_match_dytpes and this_dtype not in other_dtype:
+            for i in range(len(this_dtype)):
+
+                if not case_sensitive_dtypes:
+                    this_dtype[i] = this_dtype[i].lower()
+                    other_dtype = other_dtype.lower()
+
+                if full_match_dytpes and this_dtype[i] == other_dtype:
+                    dtype_matches.append(True)
+
+                if not full_match_dytpes and this_dtype[i] in other_dtype:
+                    dtype_matches.append(True)
+
+            # If there are no matches for any of the dtypes provided, return False
+            if not any(dtype_matches):
                 return False
 
         return True
@@ -357,14 +370,27 @@ class Schema:
                 # Get the dtype of the column in the other schema
                 other_dtype = other.columns[other_col_index][1]
 
-                if not case_sensitive_dtypes:
-                    this_dtype = this_dtype.lower()
-                    other_dtype = other_dtype.lower()
+                # There may be multiple dtypes for a column, so we need to promote scalar dtypes to
+                # lists before iterating through them
+                if isinstance(this_dtype, str):
+                    this_dtype = [this_dtype]
 
-                if full_match_dytpes and this_dtype != other_dtype:
-                    return False
+                dtype_matches = []
 
-                if not full_match_dytpes and this_dtype not in other_dtype:
+                for i in range(len(this_dtype)):
+
+                    if not case_sensitive_dtypes:
+                        this_dtype[i] = this_dtype[i].lower()
+                        other_dtype = other_dtype.lower()
+
+                    if full_match_dytpes and this_dtype[i] == other_dtype:
+                        dtype_matches.append(True)
+
+                    if not full_match_dytpes and this_dtype[i] in other_dtype:
+                        dtype_matches.append(True)
+
+                # If there are no matches for any of the dtypes provided, return False
+                if not any(dtype_matches):
                     return False
 
         return True
@@ -425,14 +451,27 @@ class Schema:
                 # Get the dtype of the column in the other schema
                 other_dtype = other.columns[other_col_index][1]
 
-                if not case_sensitive_dtypes:
-                    this_dtype = this_dtype.lower()
-                    other_dtype = other_dtype.lower()
+                # There may be multiple dtypes for a column, so we need to promote scalar dtypes to
+                # lists before iterating through them
+                if isinstance(this_dtype, str):
+                    this_dtype = [this_dtype]
 
-                if full_match_dytpes and this_dtype != other_dtype:
-                    return False
+                dtype_matches = []
 
-                if not full_match_dytpes and this_dtype not in other_dtype:
+                for i in range(len(this_dtype)):
+
+                    if not case_sensitive_dtypes:
+                        this_dtype[i] = this_dtype[i].lower()
+                        other_dtype = other_dtype.lower()
+
+                    if full_match_dytpes and this_dtype[i] == other_dtype:
+                        dtype_matches.append(True)
+
+                    if not full_match_dytpes and this_dtype[i] in other_dtype:
+                        dtype_matches.append(True)
+
+                # If there are no matches for any of the dtypes provided, return False
+                if not any(dtype_matches):
                     return False
 
         # With the subset of columns in `this_column_list`, ensure that the columns are in the same
@@ -495,14 +534,26 @@ class Schema:
                 this_dtype = self.columns[this_column_list.index(col)][1]
                 other_dtype = other.columns[other_column_list.index(col)][1]
 
-                if not case_sensitive_dtypes:
-                    this_dtype = this_dtype.lower()
-                    other_dtype = other_dtype.lower()
+                # There may be multiple dtypes for a column, so we need to promote scalar dtypes to
+                # lists before iterating through them
+                if isinstance(this_dtype, str):
+                    this_dtype = [this_dtype]
 
-                if full_match_dytpes and this_dtype != other_dtype:
-                    return False
+                dtype_matches = []
 
-                if not full_match_dytpes and this_dtype not in other_dtype:
+                for i in range(len(this_dtype)):
+                    if not case_sensitive_dtypes:
+                        this_dtype[i] = this_dtype[i].lower()
+                        other_dtype = other_dtype.lower()
+
+                    if full_match_dytpes and this_dtype[i] == other_dtype:
+                        dtype_matches.append(True)
+
+                    if not full_match_dytpes and this_dtype[i] in other_dtype:
+                        dtype_matches.append(True)
+
+                # If there are no matches for any of the dtypes provided, return False
+                if not any(dtype_matches):
                     return False
 
         return True

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2273,7 +2273,7 @@ class Validate:
 
         validation = (
             pb.Validate(data=tbl)
-            .col_vals_regex(columns="a", pattern=r"r[a-z]-\d{4}")
+            .col_vals_regex(columns="a", pattern=r"r[a-z]-[0-9]{4}")
             .interrogate()
         )
 
@@ -2289,7 +2289,7 @@ class Validate:
         ```{python}
         validation = (
             pb.Validate(data=tbl)
-            .col_vals_regex(columns="b", pattern=r"r[a-z]-\d{4}")
+            .col_vals_regex(columns="b", pattern=r"r[a-z]-[0-9]{4}")
             .interrogate()
         )
 
@@ -2827,7 +2827,7 @@ class Validate:
             .col_vals_gt(columns="item_revenue", value=0)
             .col_vals_gt(columns="session_duration", value=5)
             .col_vals_in_set(columns="item_type", set=["iap", "ad"])
-            .col_vals_regex(columns="player_id", pattern=r"[A-Z]{12}\d{3}")
+            .col_vals_regex(columns="player_id", pattern=r"[A-Z]{12}[0-9]{3}")
         )
 
         validation.interrogate(get_first_n=10)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2589,7 +2589,7 @@ class Validate:
         in_order: bool = True,
         case_sensitive_colnames: bool = True,
         case_sensitive_dtypes: bool = True,
-        full_match_dytpes: bool = True,
+        full_match_dtypes: bool = True,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
         active: bool = True,
@@ -2624,7 +2624,7 @@ class Validate:
             Should the schema match be case-sensitive with regard to column data types? If `True`,
             then the column data types in the schema and the target table must match exactly. If
             `False`, then the column data types are compared in a case-insensitive manner.
-        full_match_dytpes
+        full_match_dtypes
             Should the schema match require a full match of data types? If `True`, then the column
             data types in the schema and the target table must match exactly. If `False` then
             substring matches are allowed, so a schema data type of `Int` would match a target table
@@ -2717,7 +2717,7 @@ class Validate:
         _check_boolean_input(param=in_order, param_name="in_order")
         _check_boolean_input(param=case_sensitive_colnames, param_name="case_sensitive_colnames")
         _check_boolean_input(param=case_sensitive_dtypes, param_name="case_sensitive_dtypes")
-        _check_boolean_input(param=full_match_dytpes, param_name="full_match_dytpes")
+        _check_boolean_input(param=full_match_dtypes, param_name="full_match_dtypes")
 
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
@@ -2731,7 +2731,7 @@ class Validate:
             "in_order": in_order,
             "case_sensitive_colnames": case_sensitive_colnames,
             "case_sensitive_dtypes": case_sensitive_dtypes,
-            "full_match_dytpes": full_match_dytpes,
+            "full_match_dtypes": full_match_dtypes,
         }
 
         val_info = _ValidationInfo(
@@ -3030,7 +3030,7 @@ class Validate:
                     in_order=value["in_order"],
                     case_sensitive_colnames=value["case_sensitive_colnames"],
                     case_sensitive_dtypes=value["case_sensitive_dtypes"],
-                    full_match_dytpes=value["full_match_dytpes"],
+                    full_match_dtypes=value["full_match_dtypes"],
                     threshold=threshold,
                 ).get_test_results()
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1965,6 +1965,776 @@ def test_col_schema_match():
     )
 
 
+def test_col_schema_match_list_of_dtypes():
+
+    tbl = pl.DataFrame(
+        {
+            "a": ["apple", "banana", "cherry", "date"],
+            "b": [1, 6, 3, 5],
+            "c": [1.1, 2.2, 3.3, 4.4],
+        }
+    )
+
+    # Completely correct schema supplied to `columns=`, using 1-element lists for dtypes
+    schema = Schema(columns=[("a", ["String"]), ("b", ["Int64"]), ("c", ["Float64"])])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Having one of two dtypes being correct in 2-element lists for dtypes
+    schema = Schema(
+        columns=[("a", ["str", "String"]), ("b", ["Int64", "Int"]), ("c", ["Float64", "float"])]
+    )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Having mix of scalars and lists for dtypes
+    schema = Schema(columns=[("a", "String"), ("b", ["Int64"]), ("c", ["float", "Float64"])])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Having duplicate items in dtype lists is allowed
+    schema = Schema(
+        columns=[
+            ("a", ["str", "String", "str"]),
+            ("b", ["Int64", "Int64"]),
+            ("c", ["Float64", "Float64", "float"]),
+        ]
+    )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Having all incorrect dtypes in a list of dtypes
+    schema = Schema(
+        columns=[
+            ("a", ["wrong", "incorrect"]),
+            ("b", ["Int64", "int"]),
+            ("c", ["float", "Float64"]),
+        ]
+    )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Schema expressed in a different order (yet complete)
+    schema = Schema(columns=[("b", ["Int64", "int"]), ("c", ["float", "Float64"]), ("a", "String")])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Schema expressed in a different order (yet complete) - wrong column name
+    schema = Schema(
+        columns=[("b", ["int", "Int64"]), ("c", ["float", "Float64"]), ("wrong", ["String", "str"])]
+    )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Schema has duplicate column/dtype
+    schema = Schema(
+        columns=[
+            ("a", ["String", "str"]),
+            ("a", ["str", "String"]),
+            ("b", ["Int64", "int"]),
+            ("c", ["Float64", "float"]),
+        ]
+    )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Schema has duplicate column/dtype - wrong dtypes in one case
+    schema = Schema(
+        columns=[
+            ("a", ["String", "str"]),
+            ("a", ["wrong", "Wrong"]),
+            ("b", ["Int64", "int"]),
+            ("c", ["Float64", "float"]),
+        ]
+    )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Schema has duplicate column/dtype - wrong dtypes in both cases
+    schema = Schema(
+        columns=[
+            ("a", ["wrong", "Wrong"]),
+            ("a", ["wrong", "Wrong"]),
+            ("b", ["Int64", "int"]),
+            ("c", ["Float64", "float"]),
+        ]
+    )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Schema has duplicate column/dtype - wrong column name
+    schema = Schema(
+        columns=[
+            ("a", ["String", "str"]),
+            ("a", ["str", "String"]),
+            ("wrong", ["Int64", "int"]),
+            ("c", ["Float64", "float"]),
+        ]
+    )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Supplied schema is a subset of the actual schema (in the correct order)
+    schema = Schema(columns=[("b", ["Int64", "int"]), ("c", ["float", "Float64"])])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Supplied schema is a subset of the actual schema (in the correct order) - wrong column name
+    schema = Schema(columns=[("wrong", ["Int64", "int"]), ("c", ["Float64", "float"])])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Supplied schema is a subset of the actual schema but in a different order
+    schema = Schema(columns=[("c", ["float", "Float64"]), ("b", ["Int64", "int"])])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Supplied schema is a subset of the actual schema but in a different order - wrong column name
+    schema = Schema(columns=[("wrong", ["float", "Float64"]), ("b", ["Int64", "int"])])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Completely correct schema supplied to `columns=` except for the case mismatch in colnames
+    schema = Schema(
+        columns=[("a", ["String", "str"]), ("B", ["int", "Int64"]), ("C", ["float", "Float64"])]
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_colnames=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, complete=True, in_order=False, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, complete=False, in_order=True, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, complete=False, in_order=False, case_sensitive_colnames=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Completely correct schema supplied to `columns=` except for the case mismatch in dtypes
+    schema = Schema(
+        columns=[("a", ["string", "STR"]), ("b", ["INT64", "INT"]), ("c", ["FloaT64", "float"])]
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=True, in_order=False, case_sensitive_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=True, case_sensitive_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema, complete=False, in_order=False, case_sensitive_dtypes=False
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Completely correct schema supplied to `columns=` except for the case mismatch in
+    # colnames and dtypes
+    schema = Schema(
+        columns=[("A", ["string", "STR"]), ("b", ["INT64", "int"]), ("C", ["FloaT64", "float"])]
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_colnames=False, case_sensitive_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=True,
+            in_order=False,
+            case_sensitive_colnames=False,
+            case_sensitive_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=True,
+            case_sensitive_colnames=False,
+            case_sensitive_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=False,
+            case_sensitive_colnames=False,
+            case_sensitive_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Matching dtypes with substrings in the supplied schema (`full_match_dtypes=False` case)
+    schema = Schema(
+        columns=[("a", ["Str", "num"]), ("b", ["Int", "string"]), ("c", ["Float64", "real"])]
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, full_match_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=True, in_order=False, full_match_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=True, full_match_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=False, full_match_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Matching dtypes with substrings in the supplied schema (`full_match_dtypes=True` case)
+    schema = Schema(
+        columns=[("a", ["Str", "St"]), ("b", ["Int", "In"]), ("c", ["Float64", "Floa"])]
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, full_match_dtypes=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=True, in_order=False, full_match_dtypes=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=True, full_match_dtypes=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, complete=False, in_order=False, full_match_dtypes=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    # Matching dtypes with substrings in the supplied schema and using case-insensitive matching
+    schema = Schema(
+        columns=[("a", ["str", "s"]), ("b", ["Int", "num"]), ("c", ["float64", "float80"])]
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_dtypes=False, full_match_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=True,
+            in_order=False,
+            case_sensitive_dtypes=False,
+            full_match_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=True,
+            case_sensitive_dtypes=False,
+            full_match_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=False,
+            case_sensitive_dtypes=False,
+            full_match_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Matching dtypes with substrings in the supplied schema and using case-insensitive matching
+    # (`case_sensitive_dtypes=True` case)
+    schema = Schema(
+        columns=[("a", ["str", "str2"]), ("b", ["Int", "Inte"]), ("c", "float64", "float")]
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, case_sensitive_dtypes=True, full_match_dtypes=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=True,
+            in_order=False,
+            case_sensitive_dtypes=True,
+            full_match_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=True,
+            case_sensitive_dtypes=True,
+            full_match_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(
+            schema=schema,
+            complete=False,
+            in_order=False,
+            case_sensitive_dtypes=True,
+            full_match_dtypes=False,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+
 def test_col_schema_match_columns_only():
 
     tbl = pl.DataFrame(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1803,63 +1803,63 @@ def test_col_schema_match():
         == 1
     )
 
-    # Matching dtypes with substrings in the supplied schema (`full_match_dytpes=False` case)
+    # Matching dtypes with substrings in the supplied schema (`full_match_dtypes=False` case)
     schema = Schema(columns=[("a", "Str"), ("b", "Int"), ("c", "Float64")])
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, full_match_dytpes=False)
+        .col_schema_match(schema=schema, full_match_dtypes=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 1
     )
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, complete=True, in_order=False, full_match_dytpes=False)
+        .col_schema_match(schema=schema, complete=True, in_order=False, full_match_dtypes=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 1
     )
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, complete=False, in_order=True, full_match_dytpes=False)
+        .col_schema_match(schema=schema, complete=False, in_order=True, full_match_dtypes=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 1
     )
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, complete=False, in_order=False, full_match_dytpes=False)
+        .col_schema_match(schema=schema, complete=False, in_order=False, full_match_dtypes=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 1
     )
 
-    # Matching dtypes with substrings in the supplied schema (`full_match_dytpes=True` case)
+    # Matching dtypes with substrings in the supplied schema (`full_match_dtypes=True` case)
     schema = Schema(columns=[("a", "Str"), ("b", "Int"), ("c", "Float64")])
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, full_match_dytpes=True)
+        .col_schema_match(schema=schema, full_match_dtypes=True)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 0
     )
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, complete=True, in_order=False, full_match_dytpes=True)
+        .col_schema_match(schema=schema, complete=True, in_order=False, full_match_dtypes=True)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 0
     )
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, complete=False, in_order=True, full_match_dytpes=True)
+        .col_schema_match(schema=schema, complete=False, in_order=True, full_match_dtypes=True)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 0
     )
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, complete=False, in_order=False, full_match_dytpes=True)
+        .col_schema_match(schema=schema, complete=False, in_order=False, full_match_dtypes=True)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 0
@@ -1869,7 +1869,7 @@ def test_col_schema_match():
     schema = Schema(columns=[("a", "str"), ("b", "Int"), ("c", "float64")])
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, case_sensitive_dtypes=False, full_match_dytpes=False)
+        .col_schema_match(schema=schema, case_sensitive_dtypes=False, full_match_dtypes=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 1
@@ -1881,7 +1881,7 @@ def test_col_schema_match():
             complete=True,
             in_order=False,
             case_sensitive_dtypes=False,
-            full_match_dytpes=False,
+            full_match_dtypes=False,
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1894,7 +1894,7 @@ def test_col_schema_match():
             complete=False,
             in_order=True,
             case_sensitive_dtypes=False,
-            full_match_dytpes=False,
+            full_match_dtypes=False,
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1907,7 +1907,7 @@ def test_col_schema_match():
             complete=False,
             in_order=False,
             case_sensitive_dtypes=False,
-            full_match_dytpes=False,
+            full_match_dtypes=False,
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1919,7 +1919,7 @@ def test_col_schema_match():
     schema = Schema(columns=[("a", "str"), ("b", "Int"), ("c", "float64")])
     assert (
         Validate(data=tbl)
-        .col_schema_match(schema=schema, case_sensitive_dtypes=True, full_match_dytpes=False)
+        .col_schema_match(schema=schema, case_sensitive_dtypes=True, full_match_dtypes=False)
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 0
@@ -1931,7 +1931,7 @@ def test_col_schema_match():
             complete=True,
             in_order=False,
             case_sensitive_dtypes=True,
-            full_match_dytpes=False,
+            full_match_dtypes=False,
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1944,7 +1944,7 @@ def test_col_schema_match():
             complete=False,
             in_order=True,
             case_sensitive_dtypes=True,
-            full_match_dytpes=False,
+            full_match_dtypes=False,
         )
         .interrogate()
         .n_passed(i=1, scalar=True)
@@ -1957,7 +1957,7 @@ def test_col_schema_match():
             complete=False,
             in_order=False,
             case_sensitive_dtypes=True,
-            full_match_dytpes=False,
+            full_match_dtypes=False,
         )
         .interrogate()
         .n_passed(i=1, scalar=True)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1401,6 +1401,62 @@ def test_col_schema_match():
         == 1
     )
 
+    # Completely correct schema supplied to `columns=` (using dictionary)
+    schema = Schema(columns={"a": "String", "b": "Int64", "c": "Float64"})
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Completely correct schema (using kwargs)
+    schema = Schema(columns={"a": "String", "b": "Int64", "c": "Float64"})
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
     # Schema produced using the tbl object (supplied to `tbl=`)
     schema = Schema(tbl=tbl)
     assert (
@@ -1975,8 +2031,64 @@ def test_col_schema_match_list_of_dtypes():
         }
     )
 
-    # Completely correct schema supplied to `columns=`, using 1-element lists for dtypes
+    # Completely correct schema supplied, using 1-element lists for dtypes
     schema = Schema(columns=[("a", ["String"]), ("b", ["Int64"]), ("c", ["Float64"])])
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Completely correct schema supplied, using 1-element lists for dtypes (using dict for schema)
+    schema = Schema(columns={"a": ["String"], "b": ["Int64"], "c": ["Float64"]})
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Completely correct schema supplied, using 1-element lists for dtypes (using kwargs for schema)
+    schema = Schema(a=["String"], b=["Int64"], c=["Float64"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
         == 1
@@ -2007,6 +2119,64 @@ def test_col_schema_match_list_of_dtypes():
     schema = Schema(
         columns=[("a", ["str", "String"]), ("b", ["Int64", "Int"]), ("c", ["Float64", "float"])]
     )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Having one of two dtypes being correct in 2-element lists for dtypes (using dict for schema)
+    schema = Schema(
+        columns={"a": ["str", "String"], "b": ["Int64", "Int"], "c": ["Float64", "float"]}
+    )
+    assert (
+        Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=True, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=True)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+    assert (
+        Validate(data=tbl)
+        .col_schema_match(schema=schema, in_order=False, complete=False)
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    # Having one of two dtypes being correct in 2-element lists for dtypes (using kwargs for schema)
+    schema = Schema(a=["str", "String"], b=["Int64", "Int"], c=["Float64", "float"])
     assert (
         Validate(data=tbl).col_schema_match(schema=schema).interrogate().n_passed(i=1, scalar=True)
         == 1


### PR DESCRIPTION
This PR enhances the `Schema` class so that multiple column data types can be declared. This doesn't affect previous tests or potential workflows since a dtype can be provided as a string value (previously) or list of strings (new here). Many new tests added to verify the new functionality.

We also fix an argument typo across multiple files (the `full_match_dtypes=` arg) and update/improve the clarity of the `schema` documentation.

Typographical error fixes:

* Corrected the spelling of `full_match_dtypes=` in `pointblank/_interrogation.py`, `pointblank/schema.py`, and `pointblank/validate.py` files.

Documentation improvements:

* Enhanced the schema documentation in `pointblank/schema.py` to clarify the format for specifying column names and data types.

Regex pattern refinements:

* Updated regex patterns in `pointblank/validate.py` to use `[0-9]` instead of `\d` for better readability and consistency (also to avoid a deprecation warning)