### PR TITLE
feat: add option for info header in `preview()` table

### DIFF
--- a/pointblank/preview.py
+++ b/pointblank/preview.py
@@ -19,6 +19,7 @@ def preview(
     n_tail: int = 5,
     limit: int | None = 50,
     show_row_numbers: bool = True,
+    incl_header: bool = True,
     max_col_width: int | None = 250,
 ) -> GT:
     """
@@ -59,6 +60,9 @@ def preview(
     show_row_numbers
         Should row numbers be shown? The numbers shown reflect the row numbers of the head and tail
         in the full table.
+    incl_header
+        Should the table include a header with the table type and table dimensions? Set to `True` by
+        default.
     max_col_width
         The maximum width of the columns in pixels. This is `250` (`"250px"`) by default.
 

--- a/pointblank/preview.py
+++ b/pointblank/preview.py
@@ -7,6 +7,7 @@ from great_tables import GT, style, loc, google_font, html
 
 from pointblank.column import Column
 from pointblank.schema import Schema
+from pointblank.validate import _create_table_type_html, _create_table_dims_html
 from pointblank._utils import _get_tbl_type, _check_any_df_lib, _select_df_lib
 
 __all__ = ["preview"]
@@ -370,9 +371,29 @@ def preview(
         # Update the col_dtype_labels_dict to include the row number column (use empty string)
         col_dtype_labels_dict = {"_row_num_": ""} | col_dtype_labels_dict
 
+        # Create the label, table type, and thresholds HTML fragments
+        table_type_html = _create_table_type_html(
+            tbl_type=tbl_type, tbl_name=None, font_size="10px"
+        )
+
+        tbl_dims_html = _create_table_dims_html(
+            columns=len(col_names), rows=n_rows, font_size="10px"
+        )
+
+        # Compose the subtitle HTML fragment
+        combined_subtitle = (
+            "<div>"
+            '<div style="padding-top: 0; padding-bottom: 7px;">'
+            f"{table_type_html}"
+            f"{tbl_dims_html}"
+            "</div>"
+            "</div>"
+        )
+
     gt_tbl = (
         GT(data=data, id="pb_preview_tbl")
         .opt_table_font(font=google_font(name="IBM Plex Sans"))
+        .opt_align_table_header(align="left")
         .fmt_markdown(columns=col_names)
         .tab_style(
             style=style.css(
@@ -406,6 +427,10 @@ def preview(
         .cols_label(cases=col_dtype_labels_dict)
         .cols_width(cases=col_width_dict)
     )
+
+    if incl_header:
+        gt_tbl = gt_tbl.tab_header(title=html(combined_subtitle))
+        gt_tbl = gt_tbl.tab_options(heading_subtitle_font_size="12px")
 
     if none_values:
         for column, none_index in none_values:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5682,15 +5682,6 @@ def _create_table_type_html(
 
 def _create_table_dims_html(columns: int, rows: int, font_size: str = "10px") -> str:
 
-    if columns is None and rows is None:
-        return ""
-
-    if columns is None or columns == 0:
-        columns = "&mdash;"
-
-    if rows is None or rows == 0:
-        rows = "&mdash;"
-
     return (
         f"<span style='background-color: #eecbff; color: #333333; padding: 0.5em 0.5em; "
         f"position: inherit; text-transform: uppercase; margin: 5px 0px 5px 5px; "

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5651,7 +5651,9 @@ def _create_label_html(label: str | None, start_time: str) -> str:
     )
 
 
-def _create_table_type_html(tbl_type: str | None, tbl_name: str | None) -> str:
+def _create_table_type_html(
+    tbl_type: str | None, tbl_name: str | None, font_size: str = "smaller"
+) -> str:
 
     if tbl_type is None:
         return ""
@@ -5665,7 +5667,7 @@ def _create_table_type_html(tbl_type: str | None, tbl_name: str | None) -> str:
         return (
             f"<span style='background-color: {style['background']}; color: {style['text']}; padding: 0.5em 0.5em; "
             f"position: inherit; text-transform: uppercase; margin: 5px 10px 5px 0px; border: solid 1px {style['background']}; "
-            f"font-weight: bold; padding: 2px 10px 2px 10px; font-size: smaller;'>{style['label']}</span>"
+            f"font-weight: bold; padding: 2px 10px 2px 10px; font-size: {font_size};'>{style['label']}</span>"
         )
 
     return (

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5680,6 +5680,35 @@ def _create_table_type_html(
     )
 
 
+def _create_table_dims_html(columns: int, rows: int, font_size: str = "10px") -> str:
+
+    if columns is None and rows is None:
+        return ""
+
+    if columns is None or columns == 0:
+        columns = "&mdash;"
+
+    if rows is None or rows == 0:
+        rows = "&mdash;"
+
+    return (
+        f"<span style='background-color: #eecbff; color: #333333; padding: 0.5em 0.5em; "
+        f"position: inherit; text-transform: uppercase; margin: 5px 0px 5px 5px; "
+        f"font-weight: bold; border: solid 1px #eecbff; padding: 2px 15px 2px 15px; "
+        f"font-size: {font_size};'>Rows</span>"
+        f"<span style='background-color: none; color: #333333; padding: 0.5em 0.5em; "
+        f"position: inherit; margin: 5px 0px 5px -4px; font-weight: bold; "
+        f"border: solid 1px #eecbff; padding: 2px 15px 2px 15px; font-size: {font_size};'>{rows}</span>"
+        f"<span style='background-color: #BDE7B4; color: #333333; padding: 0.5em 0.5em; "
+        f"position: inherit; text-transform: uppercase; margin: 5px 0px 5px 3px; "
+        f"font-weight: bold; border: solid 1px #BDE7B4; padding: 2px 15px 2px 15px; "
+        f"font-size: {font_size};'>Columns</span>"
+        f"<span style='background-color: none; color: #333333; padding: 0.5em 0.5em; "
+        f"position: inherit; margin: 5px 0px 5px -4px; font-weight: bold; "
+        f"border: solid 1px #BDE7B4; padding: 2px 15px 2px 15px; font-size: {font_size};'>{columns}</span>"
+    )
+
+
 def _create_thresholds_html(thresholds: Thresholds) -> str:
 
     if thresholds == Thresholds():


### PR DESCRIPTION
This PR improves the preview functionality and handling of table metadata. A new `incl_header=` arg has been added to `preview()`, allowing for an info header to be shown. 

Additionally, missing values are now highlighted in the table with added logic to identify and highlight `None`, `NA`, and `NULL` values in the table preview.
