### PR TITLE
feat: add the `get_column_count()` and `get_row_count()` functions

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -120,4 +120,6 @@ quartodoc:
       contents:
         - name: load_dataset
         - name: preview
+        - name: get_column_count
+        - name: get_row_count
         - name: config

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -23,7 +23,7 @@ from pointblank.column import (
 from pointblank.validate import Validate, load_dataset, config
 from pointblank.schema import Schema
 from pointblank.thresholds import Thresholds
-from pointblank.preview import preview
+from pointblank.preview import preview, get_column_count, get_row_count
 
 __all__ = [
     "TF",
@@ -41,4 +41,6 @@ __all__ = [
     "load_dataset",
     "config",
     "preview",
+    "get_column_count",
+    "get_row_count",
 ]

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -164,6 +164,14 @@ def test_get_row_count(tbl_type):
     assert get_row_count(game_revenue) == 2000
 
 
+def test_get_row_count_failing():
+
+    with pytest.raises(ValueError):
+        get_row_count(None)
+    with pytest.raises(ValueError):
+        get_row_count("not a table")
+
+
 def test_get_row_count_no_polars_duckdb_table():
 
     small_table = load_dataset(dataset="small_table", tbl_type="duckdb")


### PR DESCRIPTION
This PR introduces new functions for obtaining the column (`get_column_count()`) and row (`get_row_count()`) counts of tables. There are also updates to the relevant documentation and new tests. 
