### PR TITLE
fix: make corrections to step indexing

### DIFF
--- a/pointblank/_constants.py
+++ b/pointblank/_constants.py
@@ -85,6 +85,7 @@ IBIS_BACKENDS = ["duckdb", "mysql", "postgres", "sqlite", "parquet", "memtable"]
 
 VALIDATION_REPORT_FIELDS = [
     "i",
+    "i_o",
     "assertion_type",
     "column",
     "values",

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -3219,6 +3219,10 @@ class Validate:
 
         for validation in self.validation_info:
 
+            # Set the `i` value for the validation step (this is 1-indexed)
+            index_value = self.validation_info.index(validation) + 1
+            validation.i = index_value
+
             start_time = datetime.datetime.now(datetime.timezone.utc)
 
             # Skip the validation step if it is not active but still record the time of processing

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -240,7 +240,7 @@ class _ValidationInfo:
     i
         The validation step number.
     i_o
-        The original validation step number (if a step creates multiple steps). Unused.
+        The original validation step number (if a step creates multiple steps).
     step_id
         The ID of the step (if a step creates multiple steps). Unused.
     sha1

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5452,7 +5452,11 @@ class Validate:
             Information about the validation to add.
         """
 
-        validation_info.i = len(self.validation_info) + 1
+        # Get the largest value of `i_o` in the `validation_info`
+        max_i_o = max([validation.i_o for validation in self.validation_info], default=0)
+
+        # Set the `i_o` attribute to the largest value of `i_o` plus 1
+        validation_info.i_o = max_i_o + 1
 
         self.validation_info.append(validation_info)
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5226,6 +5226,11 @@ class Validate:
         validation_info_dict.pop("active")
         validation_info_dict.pop("all_passed")
 
+        # If no interrogation performed, populate the `i` entry with a sequence of integers
+        # from `1` to the number of validation steps
+        if not interrogation_performed:
+            validation_info_dict["i"] = list(range(1, len(validation_info_dict["type_upd"]) + 1))
+
         # Create a table time string
         table_time = _create_table_time_html(time_start=self.time_start, time_end=self.time_end)
 

--- a/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_duckdb/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_duckdb/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
         "i": 1,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_parquet/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_parquet/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
         "i": 1,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_pd/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_pd/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
         "i": 1,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_pl/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_pl/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
         "i": 1,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_sqlite/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_sqlite/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
         "i": 1,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_duckdb/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_duckdb/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
-        "i": 1,
+        "i": null,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_parquet/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_parquet/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
-        "i": 1,
+        "i": null,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_pd/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_pd/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
-        "i": 1,
+        "i": null,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_pl/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_pl/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
-        "i": 1,
+        "i": null,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_sqlite/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_sqlite/validation_report.json
@@ -1,6 +1,7 @@
 [
     {
-        "i": 1,
+        "i": null,
+        "i_o": 1,
         "assertion_type": "col_vals_gt",
         "column": "x",
         "values": 0,

--- a/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_duckdb/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_duckdb/validation_report.json
@@ -1,6 +1,6 @@
 [
     {
-        "i": 1,
+        "i": null,
         "assertion_type": "col_vals_gt",
         "all_passed": null,
         "n": null,

--- a/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_parquet/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_parquet/validation_report.json
@@ -1,6 +1,6 @@
 [
     {
-        "i": 1,
+        "i": null,
         "assertion_type": "col_vals_gt",
         "all_passed": null,
         "n": null,

--- a/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_pd/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_pd/validation_report.json
@@ -1,6 +1,6 @@
 [
     {
-        "i": 1,
+        "i": null,
         "assertion_type": "col_vals_gt",
         "all_passed": null,
         "n": null,

--- a/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_pl/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_pl/validation_report.json
@@ -1,6 +1,6 @@
 [
     {
-        "i": 1,
+        "i": null,
         "assertion_type": "col_vals_gt",
         "all_passed": null,
         "n": null,

--- a/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_sqlite/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_sqlite/validation_report.json
@@ -1,6 +1,6 @@
 [
     {
-        "i": 1,
+        "i": null,
         "assertion_type": "col_vals_gt",
         "all_passed": null,
         "n": null,

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -354,7 +354,8 @@ def test_validation_plan_and_interrogation(request, tbl_fixture):
     ]
 
     # Check the attributes of the `validation_info` object
-    assert val_info.i == 1
+    assert val_info.i is None
+    assert val_info.i_o == 1
     assert val_info.assertion_type == "col_vals_gt"
     assert val_info.column == "x"
     assert val_info.values == 0


### PR DESCRIPTION
When defining validation steps, the approach is be completely lazy and not access the target table (only doing so when `interrogate()` is called). Owing to this, a single definition of a step can result in a single actual validation step, or, multiple (e.g., when using column selector functions or when providing a list of columns for applying the check).

To track this better, the PR uses the `i_o` attr to store step numbers before interrogation (i.e., each call of a validation method will increment this value) and the `i` value will be the actual sequence of validation steps (determined at interrogation time). The tabular report view uses the `i` value; in the case where the tabular report shows the validation plan w/o interrogation, the `i_o` index values will be used.