### PR TITLE
fix: when collecting target table schema, avoid conversion to Narwhals (use native DF schemas)

### DIFF
--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -209,22 +209,23 @@ class Schema:
         # Determine if this table can be converted to a Narwhals DataFrame
         table_type = _get_tbl_type(self.tbl)
 
-        if table_type == "pandas" or table_type == "polars":
+        # Collect column names and dtypes from the DataFrame and store as a list of tuples
+        if table_type == "pandas":
 
-            tbl_nw = nw.from_native(self.tbl)
-
-            schema_dict = dict(tbl_nw.schema.items())
-
+            schema_dict = dict(self.tbl.dtypes)
             schema_dict = {k: str(v) for k, v in schema_dict.items()}
+            self.columns = list(schema_dict.items())
 
+        elif table_type == "polars":
+
+            schema_dict = dict(self.tbl.schema.items())
+            schema_dict = {k: str(v) for k, v in schema_dict.items()}
             self.columns = list(schema_dict.items())
 
         elif table_type in IBIS_BACKENDS:
 
             schema_dict = dict(self.tbl.schema().items())
-
             schema_dict = {k: str(v) for k, v in schema_dict.items()}
-
             self.columns = list(schema_dict.items())
 
         else:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -91,14 +91,14 @@ def test_schema_single_column_equivalent_inputs():
 def test_schema_from_pd_table():
     schema = Schema(tbl=load_dataset(dataset="small_table", tbl_type="pandas"))
     assert schema.columns == [
-        ("date_time", "Datetime(time_unit='ns', time_zone=None)"),
-        ("date", "Datetime(time_unit='ns', time_zone=None)"),
-        ("a", "Int64"),
-        ("b", "String"),
-        ("c", "Float64"),
-        ("d", "Float64"),
-        ("e", "Boolean"),
-        ("f", "String"),
+        ("date_time", "datetime64[ns]"),
+        ("date", "datetime64[ns]"),
+        ("a", "int64"),
+        ("b", "object"),
+        ("c", "float64"),
+        ("d", "float64"),
+        ("e", "bool"),
+        ("f", "object"),
     ]
 
     assert str(type(schema.tbl)) == "<class 'pandas.core.frame.DataFrame'>"
@@ -196,14 +196,14 @@ def test_get_dtype_list_small_table_pd():
     schema = Schema(tbl=load_dataset(dataset="small_table", tbl_type="pandas"))
 
     assert schema.get_dtype_list() == [
-        "Datetime(time_unit='ns', time_zone=None)",
-        "Datetime(time_unit='ns', time_zone=None)",
-        "Int64",
-        "String",
-        "Float64",
-        "Float64",
-        "Boolean",
-        "String",
+        "datetime64[ns]",
+        "datetime64[ns]",
+        "int64",
+        "object",
+        "float64",
+        "float64",
+        "bool",
+        "object",
     ]
 
 
@@ -241,17 +241,17 @@ def test_get_dtype_list_game_revenue_pd():
     schema = Schema(tbl=load_dataset(dataset="game_revenue", tbl_type="pandas"))
 
     assert schema.get_dtype_list() == [
-        "String",
-        "String",
-        "Datetime(time_unit='ns', time_zone='UTC')",
-        "Datetime(time_unit='ns', time_zone='UTC')",
-        "String",
-        "String",
-        "Float64",
-        "Float64",
-        "Datetime(time_unit='ns', time_zone=None)",
-        "String",
-        "String",
+        "object",
+        "object",
+        "datetime64[ns, UTC]",
+        "datetime64[ns, UTC]",
+        "object",
+        "object",
+        "float64",
+        "float64",
+        "datetime64[ns]",
+        "object",
+        "object",
     ]
 
 
@@ -296,14 +296,14 @@ def test_schema_coercion_pd_to_pl():
     schema_pl = schema_pd.get_schema_coerced(to="polars")
 
     assert schema_pd.columns == [
-        ("date_time", "Datetime(time_unit='ns', time_zone=None)"),
-        ("date", "Datetime(time_unit='ns', time_zone=None)"),
-        ("a", "Int64"),
-        ("b", "String"),
-        ("c", "Float64"),
-        ("d", "Float64"),
-        ("e", "Boolean"),
-        ("f", "String"),
+        ("date_time", "datetime64[ns]"),
+        ("date", "datetime64[ns]"),
+        ("a", "int64"),
+        ("b", "object"),
+        ("c", "float64"),
+        ("d", "float64"),
+        ("e", "bool"),
+        ("f", "object"),
     ]
 
     assert schema_pl.columns == [
@@ -336,14 +336,14 @@ def test_schema_coercion_pl_to_pd():
     ]
 
     assert schema_pd.columns == [
-        ("date_time", "Datetime(time_unit='us', time_zone=None)"),
-        ("date", "Datetime(time_unit='ms', time_zone=None)"),
-        ("a", "Int64"),
-        ("b", "String"),
-        ("c", "Float64"),
-        ("d", "Float64"),
-        ("e", "Boolean"),
-        ("f", "String"),
+        ("date_time", "datetime64[us]"),
+        ("date", "datetime64[ms]"),
+        ("a", "int64"),
+        ("b", "object"),
+        ("c", "float64"),
+        ("d", "float64"),
+        ("e", "bool"),
+        ("f", "object"),
     ]
 
     assert str(type(schema_pd.tbl)) == "<class 'pandas.core.frame.DataFrame'>"


### PR DESCRIPTION
This fixes an issue in the `Schema` class (resulting in an expectation problem when using the `col_schema_match()` validation method) where the target table was converted to a Narwhals DataFrame prior to extracting information about the table's schema. This has been revised to remove that conversion and to perform schema collection for Polars and Pandas DataFrames.

Fixes: https://github.com/rich-iannone/pointblank/issues/39